### PR TITLE
feat: add English auto-translation

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,23 +11,23 @@
 </head>
 <body>
   <header class="container">
-    <h1>性格心理测试</h1>
-    <p class="sub">12 道题 · 约 2 分钟 · 本地计算，无需登录</p>
+    <h1 id="pageTitle">性格心理测试</h1>
+    <p class="sub" id="pageSub">12 道题 · 约 2 分钟 · 本地计算，无需登录</p>
   </header>
 
   <main class="container">
     <form id="quizForm">
       <div id="questions"></div>
       <div class="actions">
-        <button type="submit" class="btn">提交并查看结果</button>
+        <button type="submit" class="btn" id="submitBtn">提交并查看结果</button>
         <button type="button" id="resetBtn" class="btn ghost">清空重做</button>
       </div>
-      <p class="tiny">* 免责声明：本测试仅供娱乐与自我反思，不构成临床或诊断建议。</p>
+      <p class="tiny" id="disclaimer">* 免责声明：本测试仅供娱乐与自我反思，不构成临床或诊断建议。</p>
     </form>
   </main>
 
   <footer class="container foot">
-    <p>© 2025 Psychotest</p>
+    <p id="copyright">© 2025 Psychotest</p>
   </footer>
 
   <script src="script.js"></script>

--- a/results/analyst.html
+++ b/results/analyst.html
@@ -44,31 +44,54 @@
   </footer>
 
   <script>
-// 读取 query 分数并展示
+const LANG = navigator.language && navigator.language.startsWith('en') ? 'en' : 'zh';
+document.documentElement.lang = LANG;
+
+if (LANG === 'en') {
+  document.title = 'Analyst (Data-Driven) | Test Result';
+  document.querySelector('h1').textContent = 'Your Result';
+  document.querySelector('.result-type').innerHTML = 'Analyst (Data-Driven)<span class="badge">Non-clinical · For fun</span>';
+  document.querySelector('.kv').innerHTML = 'Type code: <code>analyst</code>';
+  document.querySelectorAll('h3')[0].textContent = 'Your Strengths';
+  document.querySelectorAll('ul')[0].innerHTML = '<li>Evidence-oriented, with rigorous reasoning and sound judgment.</li><li>Skilled at using models and data to reveal core issues.</li><li>Good at building evaluation systems and optimizing continuously.</li>';
+  document.querySelectorAll('h3')[1].textContent = 'Tips for You';
+  document.querySelectorAll('ul')[1].innerHTML = '<li>Beware of "analysis paralysis"; set clear decision points.</li><li>Co-create with business partners to ensure reports lead to action.</li><li>Collaborate with "Connectors" to translate insights into accessible, actionable language.</li>';
+  document.querySelectorAll('h3')[2].textContent = 'Scores in Each Dimension';
+  document.getElementById('scores').textContent = 'Loading...';
+  document.querySelector('.btns a').textContent = 'Take Again';
+  document.getElementById('copyBtn').textContent = 'Copy Result Link';
+  document.querySelector('footer p').textContent = '© 2025 Psychotest · This test is for entertainment and self-reflection.';
+}
+
 (function () {
   const p = new URLSearchParams(location.search);
-  const a = Number(p.get("analyst")||0);
-  const e = Number(p.get("explorer")||0);
-  const o = Number(p.get("organizer")||0);
-  const c = Number(p.get("connector")||0);
+  const a = Number(p.get('analyst') || 0);
+  const e = Number(p.get('explorer') || 0);
+  const o = Number(p.get('organizer') || 0);
+  const c = Number(p.get('connector') || 0);
+  const labels = LANG === 'en'
+    ? { connector: 'Connector', explorer: 'Explorer', organizer: 'Organizer', analyst: 'Analyst' }
+    : { connector: '连接者', explorer: '探索者', organizer: '组织者', analyst: '分析者' };
   const scores = [
-    ["连接者 connector", c],
-    ["探索者 explorer", e],
-    ["组织者 organizer", o],
-    ["分析者 analyst", a],
+    [labels.connector, c],
+    [labels.explorer, e],
+    [labels.organizer, o],
+    [labels.analyst, a],
   ];
   const total = a + e + o + c;
-  const parts = scores.map(([k,v]) => k + "：" + v).join(" ｜ ");
-  document.getElementById("scores").textContent = parts + (total ? " ｜ 总分：" + total : "");
+  const sep = LANG === 'en' ? ' | ' : ' ｜ ';
+  const colon = LANG === 'en' ? ': ' : '：';
+  const totalLabel = LANG === 'en' ? 'Total: ' : '总分：';
+  const parts = scores.map(([k, v]) => k + colon + v).join(sep);
+  document.getElementById('scores').textContent = parts + (total ? sep + totalLabel + total : '');
 })();
 
-// 复制链接
-document.getElementById("copyBtn").addEventListener("click", async () => {
+document.getElementById('copyBtn').addEventListener('click', async () => {
   try {
     await navigator.clipboard.writeText(location.href);
-    alert("已复制当前结果链接");
+    alert(LANG === 'en' ? 'Link copied.' : '已复制当前结果链接');
   } catch (err) {
-    alert("复制失败，请手动复制地址栏链接");
+    alert(LANG === 'en' ? 'Copy failed, please copy link manually' : '复制失败，请手动复制地址栏链接');
   }
 });
   </script>

--- a/results/connector.html
+++ b/results/connector.html
@@ -44,31 +44,54 @@
   </footer>
 
   <script>
-// 读取 query 分数并展示
+const LANG = navigator.language && navigator.language.startsWith('en') ? 'en' : 'zh';
+document.documentElement.lang = LANG;
+
+if (LANG === 'en') {
+  document.title = 'Connector (Social-Driven) | Test Result';
+  document.querySelector('h1').textContent = 'Your Result';
+  document.querySelector('.result-type').innerHTML = 'Connector (Social-Driven)<span class="badge">Non-clinical · For fun</span>';
+  document.querySelector('.kv').innerHTML = 'Type code: <code>connector</code>';
+  document.querySelectorAll('h3')[0].textContent = 'Your Strengths';
+  document.querySelectorAll('ul')[0].innerHTML = '<li>Great at communication and collaboration, quickly building trust and rapport.</li><li>Empowers others in the team, facilitating information flow and consensus.</li><li>Skilled at integrating resources and driving cross-department projects.</li>';
+  document.querySelectorAll('h3')[1].textContent = 'Tips for You';
+  document.querySelectorAll('ul')[1].innerHTML = '<li>Use checklists and rhythms for complex tasks to avoid "talking more, doing less".</li><li>Learn to politely decline low-priority requests to protect deep work time.</li><li>Partner with "Analysts" to support ideas with data and increase persuasiveness.</li>';
+  document.querySelectorAll('h3')[2].textContent = 'Scores in Each Dimension';
+  document.getElementById('scores').textContent = 'Loading...';
+  document.querySelector('.btns a').textContent = 'Take Again';
+  document.getElementById('copyBtn').textContent = 'Copy Result Link';
+  document.querySelector('footer p').textContent = '© 2025 Psychotest · This test is for entertainment and self-reflection.';
+}
+
 (function () {
   const p = new URLSearchParams(location.search);
-  const a = Number(p.get("analyst")||0);
-  const e = Number(p.get("explorer")||0);
-  const o = Number(p.get("organizer")||0);
-  const c = Number(p.get("connector")||0);
+  const a = Number(p.get('analyst') || 0);
+  const e = Number(p.get('explorer') || 0);
+  const o = Number(p.get('organizer') || 0);
+  const c = Number(p.get('connector') || 0);
+  const labels = LANG === 'en'
+    ? { connector: 'Connector', explorer: 'Explorer', organizer: 'Organizer', analyst: 'Analyst' }
+    : { connector: '连接者', explorer: '探索者', organizer: '组织者', analyst: '分析者' };
   const scores = [
-    ["连接者 connector", c],
-    ["探索者 explorer", e],
-    ["组织者 organizer", o],
-    ["分析者 analyst", a],
+    [labels.connector, c],
+    [labels.explorer, e],
+    [labels.organizer, o],
+    [labels.analyst, a],
   ];
   const total = a + e + o + c;
-  const parts = scores.map(([k,v]) => k + "：" + v).join(" ｜ ");
-  document.getElementById("scores").textContent = parts + (total ? " ｜ 总分：" + total : "");
+  const sep = LANG === 'en' ? ' | ' : ' ｜ ';
+  const colon = LANG === 'en' ? ': ' : '：';
+  const totalLabel = LANG === 'en' ? 'Total: ' : '总分：';
+  const parts = scores.map(([k, v]) => k + colon + v).join(sep);
+  document.getElementById('scores').textContent = parts + (total ? sep + totalLabel + total : '');
 })();
 
-// 复制链接
-document.getElementById("copyBtn").addEventListener("click", async () => {
+document.getElementById('copyBtn').addEventListener('click', async () => {
   try {
     await navigator.clipboard.writeText(location.href);
-    alert("已复制当前结果链接");
+    alert(LANG === 'en' ? 'Link copied.' : '已复制当前结果链接');
   } catch (err) {
-    alert("复制失败，请手动复制地址栏链接");
+    alert(LANG === 'en' ? 'Copy failed, please copy link manually' : '复制失败，请手动复制地址栏链接');
   }
 });
   </script>

--- a/results/explorer.html
+++ b/results/explorer.html
@@ -44,31 +44,54 @@
   </footer>
 
   <script>
-// 读取 query 分数并展示
+const LANG = navigator.language && navigator.language.startsWith('en') ? 'en' : 'zh';
+document.documentElement.lang = LANG;
+
+if (LANG === 'en') {
+  document.title = 'Explorer (Curious Innovator) | Test Result';
+  document.querySelector('h1').textContent = 'Your Result';
+  document.querySelector('.result-type').innerHTML = 'Explorer (Curious Innovator)<span class="badge">Non-clinical · For fun</span>';
+  document.querySelector('.kv').innerHTML = 'Type code: <code>explorer</code>';
+  document.querySelectorAll('h3')[0].textContent = 'Your Strengths';
+  document.querySelectorAll('ul')[0].innerHTML = '<li>Sensitive to new things and quick at trial-and-error to find breakthroughs.</li><li>Creative and good at asking questions from different perspectives.</li><li>Adapts quickly to change and embraces uncertainty.</li>';
+  document.querySelectorAll('h3')[1].textContent = 'Tips for You';
+  document.querySelectorAll('ul')[1].innerHTML = '<li>Set boundaries for each experiment: goals, time box, metrics and exit criteria.</li><li>Turn inspirations into reusable templates or SOPs.</li><li>Partner with "Organizers" to turn ideas into actionable plans.</li>';
+  document.querySelectorAll('h3')[2].textContent = 'Scores in Each Dimension';
+  document.getElementById('scores').textContent = 'Loading...';
+  document.querySelector('.btns a').textContent = 'Take Again';
+  document.getElementById('copyBtn').textContent = 'Copy Result Link';
+  document.querySelector('footer p').textContent = '© 2025 Psychotest · This test is for entertainment and self-reflection.';
+}
+
 (function () {
   const p = new URLSearchParams(location.search);
-  const a = Number(p.get("analyst")||0);
-  const e = Number(p.get("explorer")||0);
-  const o = Number(p.get("organizer")||0);
-  const c = Number(p.get("connector")||0);
+  const a = Number(p.get('analyst') || 0);
+  const e = Number(p.get('explorer') || 0);
+  const o = Number(p.get('organizer') || 0);
+  const c = Number(p.get('connector') || 0);
+  const labels = LANG === 'en'
+    ? { connector: 'Connector', explorer: 'Explorer', organizer: 'Organizer', analyst: 'Analyst' }
+    : { connector: '连接者', explorer: '探索者', organizer: '组织者', analyst: '分析者' };
   const scores = [
-    ["连接者 connector", c],
-    ["探索者 explorer", e],
-    ["组织者 organizer", o],
-    ["分析者 analyst", a],
+    [labels.connector, c],
+    [labels.explorer, e],
+    [labels.organizer, o],
+    [labels.analyst, a],
   ];
   const total = a + e + o + c;
-  const parts = scores.map(([k,v]) => k + "：" + v).join(" ｜ ");
-  document.getElementById("scores").textContent = parts + (total ? " ｜ 总分：" + total : "");
+  const sep = LANG === 'en' ? ' | ' : ' ｜ ';
+  const colon = LANG === 'en' ? ': ' : '：';
+  const totalLabel = LANG === 'en' ? 'Total: ' : '总分：';
+  const parts = scores.map(([k, v]) => k + colon + v).join(sep);
+  document.getElementById('scores').textContent = parts + (total ? sep + totalLabel + total : '');
 })();
 
-// 复制链接
-document.getElementById("copyBtn").addEventListener("click", async () => {
+document.getElementById('copyBtn').addEventListener('click', async () => {
   try {
     await navigator.clipboard.writeText(location.href);
-    alert("已复制当前结果链接");
+    alert(LANG === 'en' ? 'Link copied.' : '已复制当前结果链接');
   } catch (err) {
-    alert("复制失败，请手动复制地址栏链接");
+    alert(LANG === 'en' ? 'Copy failed, please copy link manually' : '复制失败，请手动复制地址栏链接');
   }
 });
   </script>

--- a/results/organizer.html
+++ b/results/organizer.html
@@ -44,31 +44,54 @@
   </footer>
 
   <script>
-// 读取 query 分数并展示
+const LANG = navigator.language && navigator.language.startsWith('en') ? 'en' : 'zh';
+document.documentElement.lang = LANG;
+
+if (LANG === 'en') {
+  document.title = 'Organizer (Orderly Executor) | Test Result';
+  document.querySelector('h1').textContent = 'Your Result';
+  document.querySelector('.result-type').innerHTML = 'Organizer (Orderly Executor)<span class="badge">Non-clinical · For fun</span>';
+  document.querySelector('.kv').innerHTML = 'Type code: <code>organizer</code>';
+  document.querySelectorAll('h3')[0].textContent = 'Your Strengths';
+  document.querySelectorAll('ul')[0].innerHTML = '<li>Skilled at goal breakdown, pacing, and progress tracking.</li><li>Stable and reliable, able to deliver complex projects.</li><li>Focuses on standards and quality with attention to detail.</li>';
+  document.querySelectorAll('h3')[1].textContent = 'Tips for You';
+  document.querySelectorAll('ul')[1].innerHTML = '<li>Avoid over-pursuing perfection; leave flexible buffers in plans.</li><li>Review periodically to ensure you focus on the most impactful 20%.</li><li>Work with "Explorers" to infuse innovation into processes.</li>';
+  document.querySelectorAll('h3')[2].textContent = 'Scores in Each Dimension';
+  document.getElementById('scores').textContent = 'Loading...';
+  document.querySelector('.btns a').textContent = 'Take Again';
+  document.getElementById('copyBtn').textContent = 'Copy Result Link';
+  document.querySelector('footer p').textContent = '© 2025 Psychotest · This test is for entertainment and self-reflection.';
+}
+
 (function () {
   const p = new URLSearchParams(location.search);
-  const a = Number(p.get("analyst")||0);
-  const e = Number(p.get("explorer")||0);
-  const o = Number(p.get("organizer")||0);
-  const c = Number(p.get("connector")||0);
+  const a = Number(p.get('analyst') || 0);
+  const e = Number(p.get('explorer') || 0);
+  const o = Number(p.get('organizer') || 0);
+  const c = Number(p.get('connector') || 0);
+  const labels = LANG === 'en'
+    ? { connector: 'Connector', explorer: 'Explorer', organizer: 'Organizer', analyst: 'Analyst' }
+    : { connector: '连接者', explorer: '探索者', organizer: '组织者', analyst: '分析者' };
   const scores = [
-    ["连接者 connector", c],
-    ["探索者 explorer", e],
-    ["组织者 organizer", o],
-    ["分析者 analyst", a],
+    [labels.connector, c],
+    [labels.explorer, e],
+    [labels.organizer, o],
+    [labels.analyst, a],
   ];
   const total = a + e + o + c;
-  const parts = scores.map(([k,v]) => k + "：" + v).join(" ｜ ");
-  document.getElementById("scores").textContent = parts + (total ? " ｜ 总分：" + total : "");
+  const sep = LANG === 'en' ? ' | ' : ' ｜ ';
+  const colon = LANG === 'en' ? ': ' : '：';
+  const totalLabel = LANG === 'en' ? 'Total: ' : '总分：';
+  const parts = scores.map(([k, v]) => k + colon + v).join(sep);
+  document.getElementById('scores').textContent = parts + (total ? sep + totalLabel + total : '');
 })();
 
-// 复制链接
-document.getElementById("copyBtn").addEventListener("click", async () => {
+document.getElementById('copyBtn').addEventListener('click', async () => {
   try {
     await navigator.clipboard.writeText(location.href);
-    alert("已复制当前结果链接");
+    alert(LANG === 'en' ? 'Link copied.' : '已复制当前结果链接');
   } catch (err) {
-    alert("复制失败，请手动复制地址栏链接");
+    alert(LANG === 'en' ? 'Copy failed, please copy link manually' : '复制失败，请手动复制地址栏链接');
   }
 });
   </script>

--- a/script.js
+++ b/script.js
@@ -1,80 +1,183 @@
-// ====== Question bank (12 items; 3 per dimension) ======
-const DIM_ORDER = ["connector", "explorer", "organizer", "analyst"];
-const DIM_LABEL = {
-  connector: "连接者（社交驱动）",
-  explorer: "探索者（好奇创新）",
-  organizer: "组织者（有序执行）",
-  analyst: "分析者（数据理性）",
+// Language detection
+const LANG = navigator.language && navigator.language.startsWith('en') ? 'en' : 'zh';
+
+// UI text translations
+const UI = {
+  title: {
+    zh: '性格心理测试',
+    en: 'Personality Test',
+  },
+  subtitle: {
+    zh: '12 道题 · 约 2 分钟 · 本地计算，无需登录',
+    en: '12 questions · about 2 minutes · runs locally, no login required',
+  },
+  submit: {
+    zh: '提交并查看结果',
+    en: 'Submit & View Result',
+  },
+  reset: {
+    zh: '清空重做',
+    en: 'Reset',
+  },
+  disclaimer: {
+    zh: '* 免责声明：本测试仅供娱乐与自我反思，不构成临床或诊断建议。',
+    en: '* Disclaimer: This test is for entertainment and self-reflection only and is not clinical or diagnostic advice.',
+  },
+  legend: {
+    zh: n => `第 ${n} 题`,
+    en: n => `Question ${n}`,
+  },
+  unfinished: {
+    zh: n => `还有题目未作答（第 ${n} 题）`,
+    en: n => `Question ${n} is unanswered.`,
+  },
 };
+
+// ====== Question bank (12 items; 3 per dimension) ======
+const DIM_ORDER = ['connector', 'explorer', 'organizer', 'analyst'];
 
 const QUESTIONS = [
   // connector ×3
-  { text: "在新的社交场合里，你通常能很快破冰并与人建立联系。", dim: "connector" },
-  { text: "遇到问题时，你更愿意和别人讨论，而不是独自思考。", dim: "connector" },
-  { text: "你喜欢在群聊或会议中主动发起话题。", dim: "connector" },
+  {
+    text: {
+      zh: '在新的社交场合里，你通常能很快破冰并与人建立联系。',
+      en: 'In new social settings, you can quickly break the ice and connect with others.',
+    },
+    dim: 'connector',
+  },
+  {
+    text: {
+      zh: '遇到问题时，你更愿意和别人讨论，而不是独自思考。',
+      en: 'When facing problems, you prefer discussing with others rather than thinking alone.',
+    },
+    dim: 'connector',
+  },
+  {
+    text: {
+      zh: '你喜欢在群聊或会议中主动发起话题。',
+      en: 'You like to initiate topics in group chats or meetings.',
+    },
+    dim: 'connector',
+  },
 
   // explorer ×3
-  { text: "你享受尝试全新的工具、方法或路径。", dim: "explorer" },
-  { text: "面对未知或变化，你更多是兴奋而不是焦虑。", dim: "explorer" },
-  { text: "你喜欢临时起意的安排，例如说走就走的小旅行。", dim: "explorer" },
+  {
+    text: {
+      zh: '你享受尝试全新的工具、方法或路径。',
+      en: 'You enjoy trying completely new tools, methods, or paths.',
+    },
+    dim: 'explorer',
+  },
+  {
+    text: {
+      zh: '面对未知或变化，你更多是兴奋而不是焦虑。',
+      en: 'When facing the unknown or change, you feel more excited than anxious.',
+    },
+    dim: 'explorer',
+  },
+  {
+    text: {
+      zh: '你喜欢临时起意的安排，例如说走就走的小旅行。',
+      en: 'You enjoy spur-of-the-moment plans, like spontaneous trips.',
+    },
+    dim: 'explorer',
+  },
 
   // organizer ×3
-  { text: "你会把待办事项拆解并安排到日程里逐一推进。", dim: "organizer" },
-  { text: "你更倾向于按计划一步步执行项目，少走捷径。", dim: "organizer" },
-  { text: "临时改计划会让你不适，甚至有些反感。", dim: "organizer" },
+  {
+    text: {
+      zh: '你会把待办事项拆解并安排到日程里逐一推进。',
+      en: 'You break down to-do items and schedule them step by step.',
+    },
+    dim: 'organizer',
+  },
+  {
+    text: {
+      zh: '你更倾向于按计划一步步执行项目，少走捷径。',
+      en: 'You tend to follow plans step by step, avoiding shortcuts.',
+    },
+    dim: 'organizer',
+  },
+  {
+    text: {
+      zh: '临时改计划会让你不适，甚至有些反感。',
+      en: 'Last-minute changes to plans make you uncomfortable or even resentful.',
+    },
+    dim: 'organizer',
+  },
 
   // analyst ×3
-  { text: "做重要决策前，你会先收集尽可能多的事实和数据。", dim: "analyst" },
-  { text: "你常用图表或数据来阐述观点。", dim: "analyst" },
-  { text: "对于未经验证的结论，你会保持质疑并寻求证据。", dim: "analyst" },
+  {
+    text: {
+      zh: '做重要决策前，你会先收集尽可能多的事实和数据。',
+      en: 'Before making important decisions, you gather as many facts and data as possible.',
+    },
+    dim: 'analyst',
+  },
+  {
+    text: {
+      zh: '你常用图表或数据来阐述观点。',
+      en: 'You often use charts or data to explain your ideas.',
+    },
+    dim: 'analyst',
+  },
+  {
+    text: {
+      zh: '对于未经验证的结论，你会保持质疑并寻求证据。',
+      en: 'You remain skeptical of unverified conclusions and seek evidence.',
+    },
+    dim: 'analyst',
+  },
 ];
 
 const LIKERT = [
-  { value: 1, label: "非常不同意" },
-  { value: 2, label: "不同意" },
-  { value: 3, label: "一般" },
-  { value: 4, label: "同意" },
-  { value: 5, label: "非常同意" },
+  { value: 1, label: { zh: '非常不同意', en: 'Strongly disagree' } },
+  { value: 2, label: { zh: '不同意', en: 'Disagree' } },
+  { value: 3, label: { zh: '一般', en: 'Neutral' } },
+  { value: 4, label: { zh: '同意', en: 'Agree' } },
+  { value: 5, label: { zh: '非常同意', en: 'Strongly agree' } },
 ];
 
 // ====== Render form ======
 function renderQuestions() {
-  const root = document.getElementById("questions");
-  root.innerHTML = "";
+  const root = document.getElementById('questions');
+  root.innerHTML = '';
 
   QUESTIONS.forEach((q, idx) => {
-    const fs = document.createElement("fieldset");
-    const legend = document.createElement("legend");
-    legend.textContent = `第 ${idx + 1} 题`;
+    const fs = document.createElement('fieldset');
+    const legend = document.createElement('legend');
+    legend.textContent = UI.legend[LANG](idx + 1);
     fs.appendChild(legend);
 
-    const label = document.createElement("div");
-    label.className = "q-label";
-    label.textContent = q.text;
+    const label = document.createElement('div');
+    label.className = 'q-label';
+    label.textContent = q.text[LANG];
     fs.appendChild(label);
 
-    const row = document.createElement("div");
-    row.className = "options";
+    const row = document.createElement('div');
+    row.className = 'options';
 
     LIKERT.forEach(opt => {
-      const wrap = document.createElement("label");
-      wrap.className = "opt";
-      wrap.setAttribute("data-q", String(idx));
-      wrap.setAttribute("data-v", String(opt.value));
+      const wrap = document.createElement('label');
+      wrap.className = 'opt';
+      wrap.setAttribute('data-q', String(idx));
+      wrap.setAttribute('data-v', String(opt.value));
 
-      const input = document.createElement("input");
-      input.type = "radio";
+      const input = document.createElement('input');
+      input.type = 'radio';
       input.name = `q${idx}`;
       input.value = String(opt.value);
 
       // toggle UI class when checked
-      input.addEventListener("change", () => {
-        document.querySelectorAll(`.opt[data-q="${idx}"]`).forEach(el => el.classList.remove("checked"));
-        wrap.classList.add("checked");
+      input.addEventListener('change', () => {
+        document
+          .querySelectorAll(`.opt[data-q="${idx}"]`)
+          .forEach(el => el.classList.remove('checked'));
+        wrap.classList.add('checked');
       });
 
-      const span = document.createElement("div");
-      span.textContent = `${opt.label} (${opt.value})`;
+      const span = document.createElement('div');
+      span.textContent = `${opt.label[LANG]} (${opt.value})`;
 
       wrap.appendChild(input);
       wrap.appendChild(span);
@@ -94,7 +197,7 @@ function computeAndRedirect(e) {
   for (let i = 0; i < QUESTIONS.length; i++) {
     const anyChecked = !!document.querySelector(`input[name="q${i}"]:checked`);
     if (!anyChecked) {
-      alert(`还有题目未作答（第 ${i + 1} 题）`);
+      alert(UI.unfinished[LANG](i + 1));
       return;
     }
   }
@@ -102,7 +205,10 @@ function computeAndRedirect(e) {
   // Aggregate scores
   const scores = { connector: 0, explorer: 0, organizer: 0, analyst: 0 };
   QUESTIONS.forEach((q, i) => {
-    const val = parseInt(document.querySelector(`input[name="q${i}"]:checked`).value, 10);
+    const val = parseInt(
+      document.querySelector(`input[name="q${i}"]:checked`).value,
+      10
+    );
     scores[q.dim] += val;
   });
 
@@ -122,13 +228,24 @@ function computeAndRedirect(e) {
 }
 
 function resetForm() {
-  document.getElementById("quizForm").reset();
-  document.querySelectorAll(".opt").forEach(el => el.classList.remove("checked"));
+  document.getElementById('quizForm').reset();
+  document.querySelectorAll('.opt').forEach(el => el.classList.remove('checked'));
 }
 
 // ====== Init ======
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener('DOMContentLoaded', () => {
+  document.documentElement.lang = LANG;
+  document.title = `${UI.title[LANG]}｜Psychotest`;
+  document.getElementById('pageTitle').textContent = UI.title[LANG];
+  document.getElementById('pageSub').textContent = UI.subtitle[LANG];
+  document.getElementById('submitBtn').textContent = UI.submit[LANG];
+  document.getElementById('resetBtn').textContent = UI.reset[LANG];
+  document.getElementById('disclaimer').textContent = UI.disclaimer[LANG];
+
   renderQuestions();
-  document.getElementById("quizForm").addEventListener("submit", computeAndRedirect);
-  document.getElementById("resetBtn").addEventListener("click", resetForm);
+  document
+    .getElementById('quizForm')
+    .addEventListener('submit', computeAndRedirect);
+  document.getElementById('resetBtn').addEventListener('click', resetForm);
 });
+


### PR DESCRIPTION
## Summary
- detect browser language and display English text when the user environment is English
- translate quiz questions, UI strings, and result pages so content appears in English by default for English users

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898a47e3cec83339d0ea119f29e2a3e