### PR TITLE
feat: add multi-language support

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
     <p id="copyright">© 2025 Psychotest</p>
   </footer>
 
+  <script src="translations.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/results.js
+++ b/results.js
@@ -1,0 +1,803 @@
+// Shared translation data and renderer for result pages
+function detectLang() {
+  const l = (navigator.language || 'en').toLowerCase();
+  if (l.startsWith('zh')) {
+    return /tw|hk|mo|hant/.test(l) ? 'zh-Hant' : 'zh';
+  }
+  if (l.startsWith('ja')) return 'ja';
+  if (l.startsWith('ko')) return 'ko';
+  if (l.startsWith('fr')) return 'fr';
+  if (l.startsWith('de')) return 'de';
+  if (l.startsWith('ar')) return 'ar';
+  if (l.startsWith('ru')) return 'ru';
+  if (l.startsWith('es')) return 'es';
+  return 'en';
+}
+
+const LANG = detectLang();
+document.documentElement.lang = LANG;
+document.documentElement.dir = LANG === 'ar' ? 'rtl' : 'ltr';
+
+const RES_UI = {
+  zh: {
+    header: '你的结果',
+    strengthsTitle: '你的优势',
+    tipsTitle: '给你的建议',
+    scoresTitle: '本次测评维度分数',
+    loading: '载入中…',
+    again: '再测一次',
+    copy: '复制结果链接',
+    footer: '© 2025 Psychotest · 本测试仅供娱乐与自我反思。',
+    copySuccess: '已复制当前结果链接',
+    copyFail: '复制失败，请手动复制地址栏链接',
+    labels: { connector: '连接者', explorer: '探索者', organizer: '组织者', analyst: '分析者' },
+    sep: ' ｜ ',
+    colon: '：',
+    totalLabel: '总分：',
+  },
+  'zh-Hant': {
+    header: '你的結果',
+    strengthsTitle: '你的優勢',
+    tipsTitle: '給你的建議',
+    scoresTitle: '本次測評維度分數',
+    loading: '載入中…',
+    again: '再測一次',
+    copy: '複製結果連結',
+    footer: '© 2025 Psychotest · 本測試僅供娛樂與自我反思。',
+    copySuccess: '已複製當前結果連結',
+    copyFail: '複製失敗，請手動複製地址欄連結',
+    labels: { connector: '連結者', explorer: '探索者', organizer: '組織者', analyst: '分析者' },
+    sep: ' ｜ ',
+    colon: '：',
+    totalLabel: '總分：',
+  },
+  en: {
+    header: 'Your Result',
+    strengthsTitle: 'Your Strengths',
+    tipsTitle: 'Tips for You',
+    scoresTitle: 'Scores in Each Dimension',
+    loading: 'Loading...',
+    again: 'Take Again',
+    copy: 'Copy Result Link',
+    footer: '© 2025 Psychotest · This test is for entertainment and self-reflection.',
+    copySuccess: 'Link copied.',
+    copyFail: 'Copy failed, please copy link manually',
+    labels: { connector: 'Connector', explorer: 'Explorer', organizer: 'Organizer', analyst: 'Analyst' },
+    sep: ' | ',
+    colon: ': ',
+    totalLabel: 'Total: ',
+  },
+  ja: {
+    header: '結果',
+    strengthsTitle: 'あなたの強み',
+    tipsTitle: 'アドバイス',
+    scoresTitle: '各指標のスコア',
+    loading: '読み込み中…',
+    again: 'もう一度受ける',
+    copy: '結果リンクをコピー',
+    footer: '© 2025 Psychotest · 本テストは娯楽と自己省察のためのものです。',
+    copySuccess: 'リンクをコピーしました。',
+    copyFail: 'コピーに失敗しました。手動でリンクをコピーしてください',
+    labels: { connector: '連結者', explorer: '探索者', organizer: '組織者', analyst: '分析者' },
+    sep: '｜',
+    colon: '：',
+    totalLabel: '合計：',
+  },
+  ko: {
+    header: '결과',
+    strengthsTitle: '당신의 강점',
+    tipsTitle: '조언',
+    scoresTitle: '각 차원의 점수',
+    loading: '로딩 중…',
+    again: '다시 테스트',
+    copy: '결과 링크 복사',
+    footer: '© 2025 Psychotest · 본 테스트는 오락과 자기 성찰을 위한 것입니다.',
+    copySuccess: '링크가 복사되었습니다.',
+    copyFail: '복사 실패, 링크를 직접 복사하세요',
+    labels: { connector: '연결자', explorer: '탐험가', organizer: '조직가', analyst: '분석가' },
+    sep: ' ｜ ',
+    colon: ' : ',
+    totalLabel: '총점 : ',
+  },
+  fr: {
+    header: 'Votre résultat',
+    strengthsTitle: 'Vos points forts',
+    tipsTitle: 'Conseils pour vous',
+    scoresTitle: 'Scores par dimension',
+    loading: 'Chargement…',
+    again: 'Reprendre',
+    copy: 'Copier le lien du résultat',
+    footer: '© 2025 Psychotest · Ce test est uniquement pour le divertissement et l’auto-réflexion.',
+    copySuccess: 'Lien copié.',
+    copyFail: 'Échec de la copie, veuillez copier le lien manuellement',
+    labels: { connector: 'Connecteur', explorer: 'Explorateur', organizer: 'Organisateur', analyst: 'Analyste' },
+    sep: ' | ',
+    colon: ' : ',
+    totalLabel: 'Total : ',
+  },
+  de: {
+    header: 'Dein Ergebnis',
+    strengthsTitle: 'Deine Stärken',
+    tipsTitle: 'Tipps für dich',
+    scoresTitle: 'Punkte je Dimension',
+    loading: 'Wird geladen…',
+    again: 'Erneut testen',
+    copy: 'Ergebnislink kopieren',
+    footer: '© 2025 Psychotest · Dieser Test dient nur zur Unterhaltung und Selbstreflexion.',
+    copySuccess: 'Link kopiert.',
+    copyFail: 'Kopieren fehlgeschlagen, bitte Link manuell kopieren',
+    labels: { connector: 'Vernetzer', explorer: 'Entdecker', organizer: 'Organisator', analyst: 'Analyst' },
+    sep: ' | ',
+    colon: ' : ',
+    totalLabel: 'Gesamt: ',
+  },
+  ar: {
+    header: 'نتيجتك',
+    strengthsTitle: 'نقاط قوتك',
+    tipsTitle: 'نصائح لك',
+    scoresTitle: 'النتائج في كل بُعد',
+    loading: 'جارٍ التحميل…',
+    again: 'أعد الاختبار',
+    copy: 'انسخ رابط النتيجة',
+    footer: '© 2025 Psychotest · هذا الاختبار مخصص للترفيه والتأمل الذاتي فقط.',
+    copySuccess: 'تم نسخ الرابط.',
+    copyFail: 'فشل النسخ، يرجى نسخ الرابط يدويًا',
+    labels: { connector: 'الموصِل', explorer: 'المستكشف', organizer: 'المنظِّم', analyst: 'المحلل' },
+    sep: ' | ',
+    colon: ': ',
+    totalLabel: 'المجموع: ',
+  },
+  ru: {
+    header: 'Ваш результат',
+    strengthsTitle: 'Ваши сильные стороны',
+    tipsTitle: 'Советы вам',
+    scoresTitle: 'Баллы по каждой шкале',
+    loading: 'Загрузка…',
+    again: 'Пройти снова',
+    copy: 'Скопировать ссылку',
+    footer: '© 2025 Psychotest · Этот тест предназначен лишь для развлечения и самоанализа.',
+    copySuccess: 'Ссылка скопирована.',
+    copyFail: 'Не удалось скопировать, скопируйте ссылку вручную',
+    labels: { connector: 'Коммуникатор', explorer: 'Исследователь', organizer: 'Организатор', analyst: 'Аналитик' },
+    sep: ' | ',
+    colon: ': ',
+    totalLabel: 'Итого: ',
+  },
+  es: {
+    header: 'Tu resultado',
+    strengthsTitle: 'Tus fortalezas',
+    tipsTitle: 'Consejos para ti',
+    scoresTitle: 'Puntuaciones por dimensión',
+    loading: 'Cargando…',
+    again: 'Volver a probar',
+    copy: 'Copiar enlace del resultado',
+    footer: '© 2025 Psychotest · Esta prueba es solo para entretenimiento y auto-reflexión.',
+    copySuccess: 'Enlace copiado.',
+    copyFail: 'Error al copiar, por favor copia el enlace manualmente',
+    labels: { connector: 'Conector', explorer: 'Explorador', organizer: 'Organizador', analyst: 'Analista' },
+    sep: ' | ',
+    colon: ': ',
+    totalLabel: 'Total: ',
+  },
+};
+
+const RES_CONTENT = {
+  connector: {
+    title: {
+      zh: '连接者（社交驱动）｜测试结果',
+      'zh-Hant': '連結者（社交驅動）｜測試結果',
+      en: 'Connector (Social-Driven) | Test Result',
+      ja: '連結者（社交型）｜結果',
+      ko: '연결자(사회성 중심) | 결과',
+      fr: 'Connecteur (Orienté social) | Résultat du test',
+      de: 'Vernetzer (Sozial getrieben) | Testergebnis',
+      ar: 'الموصِل (مدفوع اجتماعيًا) | نتيجة الاختبار',
+      ru: 'Коммуникатор (социально ориентированный) | Результат теста',
+      es: 'Conector (Impulsado por lo social) | Resultado del test',
+    },
+    resultType: {
+      zh: '连接者（社交驱动）<span class="badge">非临床 · 娱乐向</span>',
+      'zh-Hant': '連結者（社交驅動）<span class="badge">非臨床 · 娛樂向</span>',
+      en: 'Connector (Social-Driven)<span class="badge">Non-clinical · For fun</span>',
+      ja: '連結者（社交型）<span class="badge">非臨床・娯楽向け</span>',
+      ko: '연결자(사회성 중심)<span class="badge">비임상 · 재미용</span>',
+      fr: 'Connecteur (Orienté social)<span class="badge">Non clinique · Ludique</span>',
+      de: 'Vernetzer (Sozial getrieben)<span class="badge">Nicht klinisch · Zur Unterhaltung</span>',
+      ar: 'الموصِل (مدفوع اجتماعيًا)<span class="badge">غير سريري · للمتعة</span>',
+      ru: 'Коммуникатор (социально ориентированный)<span class="badge">Неклинический · Для развлечения</span>',
+      es: 'Conector (Impulsado por lo social)<span class="badge">No clínico · Con fines recreativos</span>',
+    },
+    kv: {
+      zh: '类型代号：<code>connector</code>',
+      'zh-Hant': '類型代號：<code>connector</code>',
+      en: 'Type code: <code>connector</code>',
+      ja: 'タイプコード：<code>connector</code>',
+      ko: '유형 코드: <code>connector</code>',
+      fr: 'Code de type : <code>connector</code>',
+      de: 'Typcode: <code>connector</code>',
+      ar: 'رمز النوع: <code>connector</code>',
+      ru: 'Код типа: <code>connector</code>',
+      es: 'Código de tipo: <code>connector</code>',
+    },
+    strengths: {
+      zh: [
+        '善于沟通与协作，能快速建立信任与默契。',
+        '在团队中为他人赋能，拉动信息流通与共识达成。',
+        '擅长资源整合，推动项目跨部门落地。',
+      ],
+      'zh-Hant': [
+        '善於溝通與協作，能快速建立信任與默契。',
+        '在團隊中為他人賦能，拉動資訊流通與共識達成。',
+        '擅長資源整合，推動項目跨部門落地。',
+      ],
+      en: [
+        'Great at communication and collaboration, quickly building trust and rapport.',
+        'Empowers others in the team, facilitating information flow and consensus.',
+        'Skilled at integrating resources and driving cross-department projects.',
+      ],
+      ja: [
+        'コミュニケーションと協力が得意で、すばやく信頼と一体感を築ける。',
+        'チームで他者を支援し、情報の流れと合意形成を促進する。',
+        'リソースの統合が得意で、部門横断のプロジェクトを推進する。',
+      ],
+      ko: [
+        '소통과 협업에 능숙하여 빠르게 신뢰와 공감대를 형성한다.',
+        '팀에서 다른 사람에게 힘을 실어주고 정보 흐름과 합의를 이끈다.',
+        '자원을 통합하여 부서 간 프로젝트를 추진하는 데 능하다.',
+      ],
+      fr: [
+        'Excellente communication et collaboration, établissant rapidement la confiance et la complicité.',
+        'Donne du pouvoir aux autres dans l’équipe, favorisant la circulation de l’information et le consensus.',
+        'Expert dans l’intégration des ressources et la mise en œuvre inter-départementale des projets.',
+      ],
+      de: [
+        'Gut in Kommunikation und Zusammenarbeit, baut schnell Vertrauen und Harmonie auf.',
+        'Stärkt andere im Team und fördert Informationsfluss sowie Konsensbildung.',
+        'Geschickt in der Ressourcenintegration und treibt bereichsübergreifende Projekte voran.',
+      ],
+      ar: [
+        'بارع في التواصل والتعاون، ويكوّن الثقة والتفاهم بسرعة.',
+        'يمكّن الآخرين في الفريق، ويسهّل تدفق المعلومات والتوصل إلى توافق.',
+        'بارع في دمج الموارد ودفع المشاريع عبر الأقسام.',
+      ],
+      ru: [
+        'Отлично общается и сотрудничает, быстро строя доверие и взаимопонимание.',
+        'Расширяет возможности других в команде, способствует обмену информацией и достижению консенсуса.',
+        'Умеет объединять ресурсы и реализовывать проекты между подразделениями.',
+      ],
+      es: [
+        'Destacas en la comunicación y la colaboración, construyendo rápidamente confianza y empatía.',
+        'Potencia a los demás en el equipo, facilitando el flujo de información y el consenso.',
+        'Hábil en integrar recursos e impulsar proyectos entre departamentos.',
+      ],
+    },
+    tips: {
+      zh: [
+        '为复杂任务建立清单与节奏板，避免“说得多做得少”。',
+        '学会对低优先级请求礼貌拒绝，保护深度工作时间。',
+        '与“分析者”搭档，用数据证明方案，提升说服力。',
+      ],
+      'zh-Hant': [
+        '為複雜任務建立清單與節奏板，避免「說得多做得少」。',
+        '學會對低優先級請求禮貌拒絕，保護深度工作時間。',
+        '與「分析者」搭檔，用數據證明方案，提升說服力。',
+      ],
+      en: [
+        'Use checklists and rhythms for complex tasks to avoid “talking more, doing less.”',
+        'Learn to politely decline low-priority requests to protect deep work time.',
+        'Partner with “Analysts” to support ideas with data and increase persuasiveness.',
+      ],
+      ja: [
+        '複雑なタスクにはチェックリストと進行表を作り、「口だけで行動が伴わない」ことを避けよう。',
+        '優先度の低い依頼は丁寧に断り、集中作業の時間を守ろう。',
+        '「分析者」と組み、データで提案を裏付けて説得力を高めよう。',
+      ],
+      ko: [
+        '복잡한 업무에는 체크리스트와 리듬표를 만들어 “말만 많고 실행은 적은” 상황을 피하라.',
+        '우선순위가 낮은 요청은 정중히 거절하여 몰입 작업 시간을 지켜라.',
+        '“분석가”와 협력하여 데이터를 통해 아이디어를 뒷받침하고 설득력을 높여라.',
+      ],
+      fr: [
+        'Créez des listes et des plannings pour les tâches complexes afin d’éviter de « beaucoup parler, peu agir ».',
+        'Apprenez à refuser poliment les demandes de faible priorité pour préserver votre temps de travail profond.',
+        'Collaborez avec des « Analystes » pour étayer les idées par des données et accroître la persuasion.',
+      ],
+      de: [
+        'Erstelle Checklisten und Zeitpläne für komplexe Aufgaben, um “viel reden, wenig tun” zu vermeiden.',
+        'Lerne höflich, Anfragen niedriger Priorität abzulehnen, um Fokuszeit zu schützen.',
+        'Arbeite mit „Analysten“ zusammen, um Ideen mit Daten zu untermauern und die Überzeugungskraft zu steigern.',
+      ],
+      ar: [
+        'أنشئ قوائم ولوحات إيقاع للمهام المعقدة لتجنب «الكلام الكثير والعمل القليل».',
+        'تعلّم رفض الطلبات ذات الأولوية المنخفضة بأدب لحماية وقت العمل العميق.',
+        'تعاون مع «المحللين» لدعم الأفكار بالبيانات وزيادة الإقناع.',
+      ],
+      ru: [
+        'Для сложных задач создавайте списки и планы, чтобы избегать «много говорить, мало делать».',
+        'Научитесь вежливо отклонять запросы низкого приоритета, чтобы защитить время для глубокого труда.',
+        'Сотрудничайте с «аналитиками», чтобы подкреплять идеи данными и повышать убедительность.',
+      ],
+      es: [
+        'Crea listas y cronogramas para las tareas complejas para evitar «hablar mucho y hacer poco».',
+        'Aprende a rechazar educadamente las solicitudes de baja prioridad para proteger tu tiempo de trabajo profundo.',
+        'Colabora con «Analistas» para respaldar tus ideas con datos y aumentar la persuasión.',
+      ],
+    },
+  },
+
+  explorer: {
+    title: {
+      zh: '探索者（好奇创新）｜测试结果',
+      'zh-Hant': '探索者（好奇創新）｜測試結果',
+      en: 'Explorer (Curious Innovator) | Test Result',
+      ja: '探索者（好奇心型）｜結果',
+      ko: '탐험가(호기심 혁신) | 결과',
+      fr: 'Explorateur (Curieux et innovant) | Résultat du test',
+      de: 'Entdecker (Neugierig und innovativ) | Testergebnis',
+      ar: 'المستكشف (فضولي ومبتكر) | نتيجة الاختبار',
+      ru: 'Исследователь (любопытный новатор) | Результат теста',
+      es: 'Explorador (Curioso e innovador) | Resultado del test',
+    },
+    resultType: {
+      zh: '探索者（好奇创新）<span class="badge">非临床 · 娱乐向</span>',
+      'zh-Hant': '探索者（好奇創新）<span class="badge">非臨床 · 娛樂向</span>',
+      en: 'Explorer (Curious Innovator)<span class="badge">Non-clinical · For fun</span>',
+      ja: '探索者（好奇心型）<span class="badge">非臨床・娯楽向け</span>',
+      ko: '탐험가(호기심 혁신)<span class="badge">비임상 · 재미용</span>',
+      fr: 'Explorateur (Curieux et innovant)<span class="badge">Non clinique · Ludique</span>',
+      de: 'Entdecker (Neugierig und innovativ)<span class="badge">Nicht klinisch · Zur Unterhaltung</span>',
+      ar: 'المستكشف (فضولي ومبتكر)<span class="badge">غير سريري · للمتعة</span>',
+      ru: 'Исследователь (любопытный новатор)<span class="badge">Неклинический · Для развлечения</span>',
+      es: 'Explorador (Curioso e innovador)<span class="badge">No clínico · Con fines recreativos</span>',
+    },
+    kv: {
+      zh: '类型代号：<code>explorer</code>',
+      'zh-Hant': '類型代號：<code>explorer</code>',
+      en: 'Type code: <code>explorer</code>',
+      ja: 'タイプコード：<code>explorer</code>',
+      ko: '유형 코드: <code>explorer</code>',
+      fr: 'Code de type : <code>explorer</code>',
+      de: 'Typcode: <code>explorer</code>',
+      ar: 'رمز النوع: <code>explorer</code>',
+      ru: 'Код типа: <code>explorer</code>',
+      es: 'Código de tipo: <code>explorer</code>',
+    },
+    strengths: {
+      zh: [
+        '对新事物敏感，能快速试错并找到突破口。',
+        '具备创意产出能力，善于提出不同视角的问题。',
+        '适应变化快，愿意拥抱不确定性。',
+      ],
+      'zh-Hant': [
+        '對新事物敏感，能快速試錯並找到突破口。',
+        '具備創意產出能力，善於提出不同視角的問題。',
+        '適應變化快，願意擁抱不確定性。',
+      ],
+      en: [
+        'Sensitive to new things and quick at trial-and-error to find breakthroughs.',
+        'Creative and good at asking questions from different perspectives.',
+        'Adapts quickly to change and embraces uncertainty.',
+      ],
+      ja: [
+        '新しい物事に敏感で、迅速に試行錯誤して突破口を見つける。',
+        '創造的な発想力があり、さまざまな視点から質問を投げかけるのが得意。',
+        '変化への適応が早く、不確実性を受け入れることをいとわない。',
+      ],
+      ko: [
+        '새로운 것에 민감하고 빠르게 시행착오를 거쳐 돌파구를 찾는다.',
+        '창의적으로 다양한 관점에서 질문을 던지는 능력이 있다.',
+        '변화에 빠르게 적응하고 불확실성을 기꺼이 받아들인다.',
+      ],
+      fr: [
+        'Sensible aux nouveautés et rapide dans l’essai-erreur pour trouver des percées.',
+        'Créatif et apte à poser des questions sous différents angles.',
+        'S’adapte rapidement au changement et accepte l’incertitude.',
+      ],
+      de: [
+        'Sensibel für Neues und schnell im Ausprobieren, um Durchbrüche zu finden.',
+        'Kreativ und gut darin, Fragen aus verschiedenen Blickwinkeln zu stellen.',
+        'Passt sich schnell Veränderungen an und nimmt Unsicherheit an.',
+      ],
+      ar: [
+        'حسّاس للأشياء الجديدة وسريع في التجربة والخطأ لإيجاد اختراقات.',
+        'مبدع وماهر في طرح الأسئلة من زوايا مختلفة.',
+        'يتكيف بسرعة مع التغيير ويحتضن عدم اليقين.',
+      ],
+      ru: [
+        'Чувствителен к новому и быстро методом проб и ошибок находит прорывы.',
+        'Креативен и умеет задавать вопросы с разных точек зрения.',
+        'Быстро адаптируется к изменениям и охотно принимает неопределенность.',
+      ],
+      es: [
+        'Sensibilizado a lo nuevo y rápido en el ensayo y error para encontrar soluciones innovadoras.',
+        'Creativo y hábil para plantear preguntas desde diferentes perspectivas.',
+        'Se adapta rápidamente al cambio y acepta la incertidumbre.',
+      ],
+    },
+    tips: {
+      zh: [
+        '为每次实验设定边界：目标、时间盒、评价指标与退出条件。',
+        '把灵感沉淀为可复用的模板或 S.O.P.。',
+        '与“组织者”搭档，将想法转化为可执行计划。',
+      ],
+      'zh-Hant': [
+        '為每次實驗設定邊界：目標、時間盒、評估指標與退出條件。',
+        '把靈感沉澱為可複用的模板或 S.O.P.。',
+        '與「組織者」搭檔，將想法轉化為可執行計畫。',
+      ],
+      en: [
+        'Set boundaries for each experiment: goals, time box, metrics, and exit criteria.',
+        'Turn inspirations into reusable templates or SOPs.',
+        'Partner with “Organizers” to turn ideas into actionable plans.',
+      ],
+      ja: [
+        '各実験には目標・タイムボックス・評価指標・退出条件といった境界を設定しよう。',
+        'ひらめきを再利用できるテンプレートや標準作業手順（SOP）に落とし込もう。',
+        '「組織者」と組んで、アイデアを実行可能な計画に変えよう。',
+      ],
+      ko: [
+        '각 실험마다 목표, 시간 제한, 평가 지표, 종료 조건 등 경계를 설정하라.',
+        '영감을 재사용 가능한 템플릿이나 표준 작업 절차(SOP)로 정리하라.',
+        '“조직가”와 협력하여 아이디어를 실행 가능한 계획으로 전환하라.',
+      ],
+      fr: [
+        'Définissez des limites pour chaque expérimentation : objectifs, durée, indicateurs et critères de sortie.',
+        'Transformez vos inspirations en modèles ou procédures opérationnelles standard réutilisables.',
+        'Collaborez avec des « Organisateurs » pour transformer les idées en plans réalisables.',
+      ],
+      de: [
+        'Setze für jedes Experiment Grenzen: Ziele, Zeitrahmen, Kennzahlen und Ausstiegskriterien.',
+        'Verwandle Einfälle in wiederverwendbare Vorlagen oder SOPs.',
+        'Arbeite mit „Organisatoren“ zusammen, um Ideen in umsetzbare Pläne zu verwandeln.',
+      ],
+      ar: [
+        'حدّد حدود كل تجربة: الأهداف، الإطار الزمني، مؤشرات التقييم ومعايير الخروج.',
+        'حوّل الإلهام إلى قوالب أو إجراءات تشغيل معيارية قابلة لإعادة الاستخدام.',
+        'تعاون مع «المنظمين» لتحويل الأفكار إلى خطط قابلة للتنفيذ.',
+      ],
+      ru: [
+        'Устанавливайте рамки для каждого эксперимента: цели, временные рамки, метрики и критерии выхода.',
+        'Превращайте вдохновение в повторно используемые шаблоны или стандартные процедуры (SOP).',
+        'Сотрудничайте с «организаторами», чтобы превращать идеи в реализуемые планы.',
+      ],
+      es: [
+        'Define límites para cada experimento: objetivos, tiempo, indicadores y criterios de salida.',
+        'Convierte las inspiraciones en plantillas reutilizables o procedimientos estándar (SOP).',
+        'Colabora con «Organizadores» para convertir ideas en planes ejecutables.',
+      ],
+    },
+  },
+
+  organizer: {
+    title: {
+      zh: '组织者（有序执行）｜测试结果',
+      'zh-Hant': '組織者（有序執行）｜測試結果',
+      en: 'Organizer (Orderly Executor) | Test Result',
+      ja: '組織者（秩序実行）｜結果',
+      ko: '조직가(체계 실행) | 결과',
+      fr: 'Organisateur (Exécution ordonnée) | Résultat du test',
+      de: 'Organisator (Ordnungsgemäß ausführend) | Testergebnis',
+      ar: 'المنظِّم (تنفيذ منظم) | نتيجة الاختبار',
+      ru: 'Организатор (упорядоченный исполнитель) | Результат теста',
+      es: 'Organizador (Ejecución ordenada) | Resultado del test',
+    },
+    resultType: {
+      zh: '组织者（有序执行）<span class="badge">非临床 · 娱乐向</span>',
+      'zh-Hant': '組織者（有序執行）<span class="badge">非臨床 · 娛樂向</span>',
+      en: 'Organizer (Orderly Executor)<span class="badge">Non-clinical · For fun</span>',
+      ja: '組織者（秩序実行）<span class="badge">非臨床・娯楽向け</span>',
+      ko: '조직가(체계 실행)<span class="badge">비임상 · 재미용</span>',
+      fr: 'Organisateur (Exécution ordonnée)<span class="badge">Non clinique · Ludique</span>',
+      de: 'Organisator (Ordnungsgemäß ausführend)<span class="badge">Nicht klinisch · Zur Unterhaltung</span>',
+      ar: 'المنظِّم (تنفيذ منظم)<span class="badge">غير سريري · للمتعة</span>',
+      ru: 'Организатор (упорядоченный исполнитель)<span class="badge">Неклинический · Для развлечения</span>',
+      es: 'Organizador (Ejecución ordenada)<span class="badge">No clínico · Con fines recreativos</span>',
+    },
+    kv: {
+      zh: '类型代号：<code>organizer</code>',
+      'zh-Hant': '類型代號：<code>organizer</code>',
+      en: 'Type code: <code>organizer</code>',
+      ja: 'タイプコード：<code>organizer</code>',
+      ko: '유형 코드: <code>organizer</code>',
+      fr: 'Code de type : <code>organizer</code>',
+      de: 'Typcode: <code>organizer</code>',
+      ar: 'رمز النوع: <code>organizer</code>',
+      ru: 'Код типа: <code>organizer</code>',
+      es: 'Código de tipo: <code>organizer</code>',
+    },
+    strengths: {
+      zh: [
+        '擅长目标拆解、节奏管理与进度跟踪。',
+        '稳定可靠，能把复杂项目落地成形。',
+        '注重规范与质量，细节把控到位。',
+      ],
+      'zh-Hant': [
+        '擅長目標拆解、節奏管理與進度追蹤。',
+        '穩定可靠，能把複雜項目落地成形。',
+        '注重規範與品質，細節把控到位。',
+      ],
+      en: [
+        'Skilled at goal breakdown, pacing, and progress tracking.',
+        'Stable and reliable, able to deliver complex projects.',
+        'Focuses on standards and quality with attention to detail.',
+      ],
+      ja: [
+        '目標の分解、ペース管理、進捗トラッキングが得意。',
+        '安定して信頼でき、複雑なプロジェクトを形にできる。',
+        '規範と品質を重視し、細部まで目が行き届いている。',
+      ],
+      ko: [
+        '목표 세분화, 페이스 관리, 진척 추적에 능하다.',
+        '안정적이고 신뢰할 수 있으며 복잡한 프로젝트를 완성할 수 있다.',
+        '규범과 품질을 중시하며 세부 사항까지 철저히 관리한다.',
+      ],
+      fr: [
+        'Compétent en décomposition d’objectifs, gestion du rythme et suivi des progrès.',
+        'Stable et fiable, capable de concrétiser des projets complexes.',
+        'Souci des normes et de la qualité, avec un contrôle précis des détails.',
+      ],
+      de: [
+        'Gut in Zielzerlegung, Rhythmusmanagement und Fortschrittsverfolgung.',
+        'Stabil und zuverlässig, kann komplexe Projekte verwirklichen.',
+        'Legt Wert auf Standards und Qualität, achtet genau auf Details.',
+      ],
+      ar: [
+        'بارع في تفكيك الأهداف، وإدارة الوتيرة، وتتبع التقدم.',
+        'مستقر وموثوق، قادر على تنفيذ المشاريع المعقدة.',
+        'يولي أهمية للمعايير والجودة مع السيطرة الدقيقة على التفاصيل.',
+      ],
+      ru: [
+        'Хорошо разбивает цели, управляет темпом и отслеживает прогресс.',
+        'Стабилен и надежен, способен воплощать сложные проекты.',
+        'Уделяет внимание стандартам и качеству, тщательно контролируя детали.',
+      ],
+      es: [
+        'Hábil en descomponer objetivos, gestionar el ritmo y hacer seguimiento del progreso.',
+        'Estable y confiable, capaz de llevar a cabo proyectos complejos.',
+        'Se enfoca en las normas y la calidad, cuidando los detalles.',
+      ],
+    },
+    tips: {
+      zh: [
+        '避免过度追求完美，给计划预留灵活缓冲区。',
+        '定期回顾是否“为做而做”，聚焦影响最大的 20%。',
+        '与“探索者”合作，为流程注入创新活力。',
+      ],
+      'zh-Hant': [
+        '避免過度追求完美，給計畫預留靈活緩衝區。',
+        '定期回顧是否「為做而做」，聚焦影響最大的 20%。',
+        '與「探索者」合作，為流程注入創新活力。',
+      ],
+      en: [
+        'Avoid over-pursuing perfection; leave flexible buffers in plans.',
+        'Review periodically to ensure you focus on the most impactful 20%.',
+        'Work with “Explorers” to infuse innovation into processes.',
+      ],
+      ja: [
+        '完璧を求めすぎず、計画には柔軟なバッファーを設けよう。',
+        '定期的に振り返り、最も影響の大きい20%に集中できているか確認しよう。',
+        '「探索者」と協力し、プロセスに革新的な活力を注入しよう。',
+      ],
+      ko: [
+        '완벽을 과도하게 추구하지 말고 계획에 유연한 완충 구간을 남겨라.',
+        '정기적으로 돌아보며 가장 영향력 있는 20%에 집중하고 있는지 확인하라.',
+        '“탐험가”와 협력하여 프로세스에 혁신적 활력을 주입하라.',
+      ],
+      fr: [
+        'Évitez de chercher la perfection excessive; prévoyez des marges de manœuvre dans vos plans.',
+        'Reconsidérez régulièrement pour vous assurer de vous concentrer sur les 20% les plus impactants.',
+        'Collaborez avec des « Explorateurs » pour insuffler de l’innovation dans les processus.',
+      ],
+      de: [
+        'Vermeide übermäßigen Perfektionismus und lasse flexible Puffer im Plan.',
+        'Überprüfe regelmäßig, ob du dich auf die wirkungsvollsten 20 % konzentrierst.',
+        'Arbeite mit „Entdeckern“ zusammen, um Prozessen innovative Energie zu verleihen.',
+      ],
+      ar: [
+        'تجنب السعي المفرط نحو الكمال واترك هوامش مرنة في الخطط.',
+        'راجع دوريًا للتأكد من أنك تركز على أهم 20٪ من التأثير.',
+        'تعاون مع «المستكشفين» لضخ الابتكار في العمليات.',
+      ],
+      ru: [
+        'Избегайте чрезмерного стремления к совершенству; оставляйте гибкие буферы в планах.',
+        'Регулярно анализируйте, чтобы сосредоточиться на наиболее значимых 20 %.',
+        'Сотрудничайте с «исследователями», чтобы привносить инновации в процессы.',
+      ],
+      es: [
+        'Evita perseguir demasiado la perfección; deja márgenes flexibles en los planes.',
+        'Revisa periódicamente para asegurarte de centrarte en el 20 % con mayor impacto.',
+        'Colabora con «Exploradores» para inyectar innovación en los procesos.',
+      ],
+    },
+  },
+
+  analyst: {
+    title: {
+      zh: '分析者（数据理性）｜测试结果',
+      'zh-Hant': '分析者（數據理性）｜測試結果',
+      en: 'Analyst (Data-Driven) | Test Result',
+      ja: '分析者（データ志向）｜結果',
+      ko: '분석가(데이터 중심) | 결과',
+      fr: 'Analyste (Axé sur les données) | Résultat du test',
+      de: 'Analyst (Datenorientiert) | Testergebnis',
+      ar: 'المحلل (مدفوع بالبيانات) | نتيجة الاختبار',
+      ru: 'Аналитик (ориентированный на данные) | Результат теста',
+      es: 'Analista (Orientado a los datos) | Resultado del test',
+    },
+    resultType: {
+      zh: '分析者（数据理性）<span class="badge">非临床 · 娱乐向</span>',
+      'zh-Hant': '分析者（數據理性）<span class="badge">非臨床 · 娛樂向</span>',
+      en: 'Analyst (Data-Driven)<span class="badge">Non-clinical · For fun</span>',
+      ja: '分析者（データ志向）<span class="badge">非臨床・娯楽向け</span>',
+      ko: '분석가(데이터 중심)<span class="badge">비임상 · 재미용</span>',
+      fr: 'Analyste (Axé sur les données)<span class="badge">Non clinique · Ludique</span>',
+      de: 'Analyst (Datenorientiert)<span class="badge">Nicht klinisch · Zur Unterhaltung</span>',
+      ar: 'المحلل (مدفوع بالبيانات)<span class="badge">غير سريري · للمتعة</span>',
+      ru: 'Аналитик (ориентированный на данные)<span class="badge">Неклинический · Для развлечения</span>',
+      es: 'Analista (Orientado a los datos)<span class="badge">No clínico · Con fines recreativos</span>',
+    },
+    kv: {
+      zh: '类型代号：<code>analyst</code>',
+      'zh-Hant': '類型代號：<code>analyst</code>',
+      en: 'Type code: <code>analyst</code>',
+      ja: 'タイプコード：<code>analyst</code>',
+      ko: '유형 코드: <code>analyst</code>',
+      fr: 'Code de type : <code>analyst</code>',
+      de: 'Typcode: <code>analyst</code>',
+      ar: 'رمز النوع: <code>analyst</code>',
+      ru: 'Код типа: <code>analyst</code>',
+      es: 'Código de tipo: <code>analyst</code>',
+    },
+    strengths: {
+      zh: [
+        '以证据为导向，推理严谨、判断稳健。',
+        '善用模型和数据揭示本质问题。',
+        '擅长构建评估体系，持续优化。',
+      ],
+      'zh-Hant': [
+        '以證據為導向，推理嚴謹、判斷穩健。',
+        '善用模型和數據揭示本質問題。',
+        '擅長構建評估體系，持續優化。',
+      ],
+      en: [
+        'Evidence-oriented, with rigorous reasoning and sound judgment.',
+        'Skilled at using models and data to reveal core issues.',
+        'Good at building evaluation systems and optimizing continuously.',
+      ],
+      ja: [
+        '証拠重視で、推論が緻密かつ判断が確か。',
+        'モデルやデータを活用して本質的な問題を明らかにするのが得意。',
+        '評価システムの構築が得意で、継続的な最適化を行う。',
+      ],
+      ko: [
+        '증거 중심으로 사고하며, 추리가 치밀하고 판단이 안정적이다.',
+        '모델과 데이터를 활용해 본질적인 문제를 드러내는 데 능숙하다.',
+        '평가 체계를 구축하고 지속적으로 최적화하는 데 능하다.',
+      ],
+      fr: [
+        'Orienté vers les preuves, avec un raisonnement rigoureux et un jugement solide.',
+        'Sait utiliser modèles et données pour révéler les problèmes essentiels.',
+        'Doué pour construire des systèmes d’évaluation et les optimiser en continu.',
+      ],
+      de: [
+        'Beweisorientiert, mit strenger Argumentation und fundiertem Urteilsvermögen.',
+        'Setzt Modelle und Daten geschickt ein, um Kernprobleme aufzudecken.',
+        'Gut im Aufbau von Bewertungssystemen und deren kontinuierlicher Optimierung.',
+      ],
+      ar: [
+        'موجّه بالأدلة مع منطق صارم وحكم متين.',
+        'ماهر في استخدام النماذج والبيانات للكشف عن القضايا الجوهرية.',
+        'بارع في بناء أنظمة التقييم وتحسينها باستمرار.',
+      ],
+      ru: [
+        'Ориентируется на доказательства, с строгой логикой и надежными суждениями.',
+        'Умеет использовать модели и данные для выявления ключевых проблем.',
+        'Хорошо строит системы оценки и постоянно их улучшает.',
+      ],
+      es: [
+        'Orientado a la evidencia, con razonamiento riguroso y juicio sólido.',
+        'Hábil en utilizar modelos y datos para revelar los problemas esenciales.',
+        'Bueno construyendo sistemas de evaluación y optimizándolos continuamente.',
+      ],
+    },
+    tips: {
+      zh: [
+        '警惕“分析瘫痪”，给研究设定明确的决策节点。',
+        '与业务伙伴共创，避免报告“只看不改”。',
+        '与“连接者”协作，把洞见翻译为通俗可执行的话术。',
+      ],
+      'zh-Hant': [
+        '警惕「分析癱瘓」，給研究設定明確的決策節點。',
+        '與業務夥伴共創，避免報告「只看不改」。',
+        '與「連結者」協作，把洞見翻譯為通俗可執行的話術。',
+      ],
+      en: [
+        'Beware of “analysis paralysis”; set clear decision points.',
+        'Co-create with business partners to ensure reports lead to action.',
+        'Collaborate with “Connectors” to translate insights into accessible, actionable language.',
+      ],
+      ja: [
+        '「分析麻痺」に注意し、明確な意思決定ポイントを設けよう。',
+        'ビジネスパートナーと共創し、報告が「見るだけで終わる」ことを防ごう。',
+        '「連結者」と協力し、洞察をわかりやすく実行可能な言葉に落とし込もう。',
+      ],
+      ko: [
+        '“분석 마비”를 경계하고 명확한 의사 결정 지점을 설정하라.',
+        '비즈니스 파트너와 함께 만들어 보고서가 “보기만 하고 바뀌지 않는” 일을 막아라.',
+        '“연결자”와 협업하여 통찰을 이해하기 쉽고 실행 가능한 언어로 옮겨라.',
+      ],
+      fr: [
+        'Attention à la « paralysie par l’analyse »; définissez des points de décision clairs.',
+        'Co-créez avec les partenaires métiers pour que les rapports conduisent à l’action.',
+        'Collaborez avec des « Connecteurs » pour traduire les idées en langage accessible et actionnable.',
+      ],
+      de: [
+        'Hüte dich vor „Analyse-Paralyse“ und setze klare Entscheidungspunkte.',
+        'Arbeite mit Geschäftspartnern zusammen, damit Berichte zu Taten führen.',
+        'Arbeite mit „Vernetzer:innen“ zusammen, um Erkenntnisse in verständliche, umsetzbare Sprache zu übersetzen.',
+      ],
+      ar: [
+        'احذر «شلل التحليل» وحدّد نقاط قرار واضحة.',
+        'تعاون مع شركاء الأعمال لضمان أن تؤدي التقارير إلى إجراءات.',
+        'تعاون مع «الروابط» لتحويل الرؤى إلى لغة مفهومة وقابلة للتنفيذ.',
+      ],
+      ru: [
+        'Остерегайтесь «аналитического паралича»; устанавливайте четкие точки принятия решений.',
+        'Сотрудничайте с бизнес-партнёрами, чтобы отчёты приводили к действиям.',
+        'Сотрудничайте с «коммуникаторами», чтобы переводить инсайты на понятный и прикладной язык.',
+      ],
+      es: [
+        'Cuidado con la «parálisis por análisis»; establece puntos claros de decisión.',
+        'Co-crea con socios de negocio para que los informes conduzcan a acciones.',
+        'Colabora con «Conectores» para traducir las ideas en un lenguaje comprensible y accionable.',
+      ],
+    },
+  },
+};
+
+function initResult(type) {
+  const ui = RES_UI[LANG];
+  const c = RES_CONTENT[type];
+
+  document.title = c.title[LANG];
+  document.querySelector('h1').textContent = ui.header;
+  document.querySelector('.result-type').innerHTML = c.resultType[LANG];
+  document.querySelector('.kv').innerHTML = c.kv[LANG];
+  document.querySelectorAll('h3')[0].textContent = ui.strengthsTitle;
+  document.querySelectorAll('ul')[0].innerHTML = c.strengths[LANG].map(li => `<li>${li}</li>`).join('');
+  document.querySelectorAll('h3')[1].textContent = ui.tipsTitle;
+  document.querySelectorAll('ul')[1].innerHTML = c.tips[LANG].map(li => `<li>${li}</li>`).join('');
+  document.querySelectorAll('h3')[2].textContent = ui.scoresTitle;
+  document.getElementById('scores').textContent = ui.loading;
+  document.querySelector('.btns a').textContent = ui.again;
+  document.getElementById('copyBtn').textContent = ui.copy;
+  document.querySelector('footer p').textContent = ui.footer;
+
+  (function () {
+    const p = new URLSearchParams(location.search);
+    const a = Number(p.get('analyst') || 0);
+    const e = Number(p.get('explorer') || 0);
+    const o = Number(p.get('organizer') || 0);
+    const c = Number(p.get('connector') || 0);
+    const labels = ui.labels;
+    const scores = [
+      [labels.connector, c],
+      [labels.explorer, e],
+      [labels.organizer, o],
+      [labels.analyst, a],
+    ];
+    const total = a + e + o + c;
+    const parts = scores.map(([k, v]) => k + ui.colon + v).join(ui.sep);
+    document.getElementById('scores').textContent = parts + (total ? ui.sep + ui.totalLabel + total : '');
+  })();
+
+  document.getElementById('copyBtn').addEventListener('click', async () => {
+    try {
+      await navigator.clipboard.writeText(location.href);
+      alert(ui.copySuccess);
+    } catch (err) {
+      alert(ui.copyFail);
+    }
+  });
+}
+

--- a/results/analyst.html
+++ b/results/analyst.html
@@ -43,57 +43,9 @@
     <p>© 2025 Psychotest · 本测试仅供娱乐与自我反思。</p>
   </footer>
 
+  <script src="../results.js"></script>
   <script>
-const LANG = navigator.language && navigator.language.startsWith('en') ? 'en' : 'zh';
-document.documentElement.lang = LANG;
-
-if (LANG === 'en') {
-  document.title = 'Analyst (Data-Driven) | Test Result';
-  document.querySelector('h1').textContent = 'Your Result';
-  document.querySelector('.result-type').innerHTML = 'Analyst (Data-Driven)<span class="badge">Non-clinical · For fun</span>';
-  document.querySelector('.kv').innerHTML = 'Type code: <code>analyst</code>';
-  document.querySelectorAll('h3')[0].textContent = 'Your Strengths';
-  document.querySelectorAll('ul')[0].innerHTML = '<li>Evidence-oriented, with rigorous reasoning and sound judgment.</li><li>Skilled at using models and data to reveal core issues.</li><li>Good at building evaluation systems and optimizing continuously.</li>';
-  document.querySelectorAll('h3')[1].textContent = 'Tips for You';
-  document.querySelectorAll('ul')[1].innerHTML = '<li>Beware of "analysis paralysis"; set clear decision points.</li><li>Co-create with business partners to ensure reports lead to action.</li><li>Collaborate with "Connectors" to translate insights into accessible, actionable language.</li>';
-  document.querySelectorAll('h3')[2].textContent = 'Scores in Each Dimension';
-  document.getElementById('scores').textContent = 'Loading...';
-  document.querySelector('.btns a').textContent = 'Take Again';
-  document.getElementById('copyBtn').textContent = 'Copy Result Link';
-  document.querySelector('footer p').textContent = '© 2025 Psychotest · This test is for entertainment and self-reflection.';
-}
-
-(function () {
-  const p = new URLSearchParams(location.search);
-  const a = Number(p.get('analyst') || 0);
-  const e = Number(p.get('explorer') || 0);
-  const o = Number(p.get('organizer') || 0);
-  const c = Number(p.get('connector') || 0);
-  const labels = LANG === 'en'
-    ? { connector: 'Connector', explorer: 'Explorer', organizer: 'Organizer', analyst: 'Analyst' }
-    : { connector: '连接者', explorer: '探索者', organizer: '组织者', analyst: '分析者' };
-  const scores = [
-    [labels.connector, c],
-    [labels.explorer, e],
-    [labels.organizer, o],
-    [labels.analyst, a],
-  ];
-  const total = a + e + o + c;
-  const sep = LANG === 'en' ? ' | ' : ' ｜ ';
-  const colon = LANG === 'en' ? ': ' : '：';
-  const totalLabel = LANG === 'en' ? 'Total: ' : '总分：';
-  const parts = scores.map(([k, v]) => k + colon + v).join(sep);
-  document.getElementById('scores').textContent = parts + (total ? sep + totalLabel + total : '');
-})();
-
-document.getElementById('copyBtn').addEventListener('click', async () => {
-  try {
-    await navigator.clipboard.writeText(location.href);
-    alert(LANG === 'en' ? 'Link copied.' : '已复制当前结果链接');
-  } catch (err) {
-    alert(LANG === 'en' ? 'Copy failed, please copy link manually' : '复制失败，请手动复制地址栏链接');
-  }
-});
+    initResult('analyst');
   </script>
 </body>
 </html>

--- a/results/connector.html
+++ b/results/connector.html
@@ -43,57 +43,9 @@
     <p>© 2025 Psychotest · 本测试仅供娱乐与自我反思。</p>
   </footer>
 
+  <script src="../results.js"></script>
   <script>
-const LANG = navigator.language && navigator.language.startsWith('en') ? 'en' : 'zh';
-document.documentElement.lang = LANG;
-
-if (LANG === 'en') {
-  document.title = 'Connector (Social-Driven) | Test Result';
-  document.querySelector('h1').textContent = 'Your Result';
-  document.querySelector('.result-type').innerHTML = 'Connector (Social-Driven)<span class="badge">Non-clinical · For fun</span>';
-  document.querySelector('.kv').innerHTML = 'Type code: <code>connector</code>';
-  document.querySelectorAll('h3')[0].textContent = 'Your Strengths';
-  document.querySelectorAll('ul')[0].innerHTML = '<li>Great at communication and collaboration, quickly building trust and rapport.</li><li>Empowers others in the team, facilitating information flow and consensus.</li><li>Skilled at integrating resources and driving cross-department projects.</li>';
-  document.querySelectorAll('h3')[1].textContent = 'Tips for You';
-  document.querySelectorAll('ul')[1].innerHTML = '<li>Use checklists and rhythms for complex tasks to avoid "talking more, doing less".</li><li>Learn to politely decline low-priority requests to protect deep work time.</li><li>Partner with "Analysts" to support ideas with data and increase persuasiveness.</li>';
-  document.querySelectorAll('h3')[2].textContent = 'Scores in Each Dimension';
-  document.getElementById('scores').textContent = 'Loading...';
-  document.querySelector('.btns a').textContent = 'Take Again';
-  document.getElementById('copyBtn').textContent = 'Copy Result Link';
-  document.querySelector('footer p').textContent = '© 2025 Psychotest · This test is for entertainment and self-reflection.';
-}
-
-(function () {
-  const p = new URLSearchParams(location.search);
-  const a = Number(p.get('analyst') || 0);
-  const e = Number(p.get('explorer') || 0);
-  const o = Number(p.get('organizer') || 0);
-  const c = Number(p.get('connector') || 0);
-  const labels = LANG === 'en'
-    ? { connector: 'Connector', explorer: 'Explorer', organizer: 'Organizer', analyst: 'Analyst' }
-    : { connector: '连接者', explorer: '探索者', organizer: '组织者', analyst: '分析者' };
-  const scores = [
-    [labels.connector, c],
-    [labels.explorer, e],
-    [labels.organizer, o],
-    [labels.analyst, a],
-  ];
-  const total = a + e + o + c;
-  const sep = LANG === 'en' ? ' | ' : ' ｜ ';
-  const colon = LANG === 'en' ? ': ' : '：';
-  const totalLabel = LANG === 'en' ? 'Total: ' : '总分：';
-  const parts = scores.map(([k, v]) => k + colon + v).join(sep);
-  document.getElementById('scores').textContent = parts + (total ? sep + totalLabel + total : '');
-})();
-
-document.getElementById('copyBtn').addEventListener('click', async () => {
-  try {
-    await navigator.clipboard.writeText(location.href);
-    alert(LANG === 'en' ? 'Link copied.' : '已复制当前结果链接');
-  } catch (err) {
-    alert(LANG === 'en' ? 'Copy failed, please copy link manually' : '复制失败，请手动复制地址栏链接');
-  }
-});
+    initResult('connector');
   </script>
 </body>
 </html>

--- a/results/explorer.html
+++ b/results/explorer.html
@@ -43,57 +43,9 @@
     <p>© 2025 Psychotest · 本测试仅供娱乐与自我反思。</p>
   </footer>
 
+  <script src="../results.js"></script>
   <script>
-const LANG = navigator.language && navigator.language.startsWith('en') ? 'en' : 'zh';
-document.documentElement.lang = LANG;
-
-if (LANG === 'en') {
-  document.title = 'Explorer (Curious Innovator) | Test Result';
-  document.querySelector('h1').textContent = 'Your Result';
-  document.querySelector('.result-type').innerHTML = 'Explorer (Curious Innovator)<span class="badge">Non-clinical · For fun</span>';
-  document.querySelector('.kv').innerHTML = 'Type code: <code>explorer</code>';
-  document.querySelectorAll('h3')[0].textContent = 'Your Strengths';
-  document.querySelectorAll('ul')[0].innerHTML = '<li>Sensitive to new things and quick at trial-and-error to find breakthroughs.</li><li>Creative and good at asking questions from different perspectives.</li><li>Adapts quickly to change and embraces uncertainty.</li>';
-  document.querySelectorAll('h3')[1].textContent = 'Tips for You';
-  document.querySelectorAll('ul')[1].innerHTML = '<li>Set boundaries for each experiment: goals, time box, metrics and exit criteria.</li><li>Turn inspirations into reusable templates or SOPs.</li><li>Partner with "Organizers" to turn ideas into actionable plans.</li>';
-  document.querySelectorAll('h3')[2].textContent = 'Scores in Each Dimension';
-  document.getElementById('scores').textContent = 'Loading...';
-  document.querySelector('.btns a').textContent = 'Take Again';
-  document.getElementById('copyBtn').textContent = 'Copy Result Link';
-  document.querySelector('footer p').textContent = '© 2025 Psychotest · This test is for entertainment and self-reflection.';
-}
-
-(function () {
-  const p = new URLSearchParams(location.search);
-  const a = Number(p.get('analyst') || 0);
-  const e = Number(p.get('explorer') || 0);
-  const o = Number(p.get('organizer') || 0);
-  const c = Number(p.get('connector') || 0);
-  const labels = LANG === 'en'
-    ? { connector: 'Connector', explorer: 'Explorer', organizer: 'Organizer', analyst: 'Analyst' }
-    : { connector: '连接者', explorer: '探索者', organizer: '组织者', analyst: '分析者' };
-  const scores = [
-    [labels.connector, c],
-    [labels.explorer, e],
-    [labels.organizer, o],
-    [labels.analyst, a],
-  ];
-  const total = a + e + o + c;
-  const sep = LANG === 'en' ? ' | ' : ' ｜ ';
-  const colon = LANG === 'en' ? ': ' : '：';
-  const totalLabel = LANG === 'en' ? 'Total: ' : '总分：';
-  const parts = scores.map(([k, v]) => k + colon + v).join(sep);
-  document.getElementById('scores').textContent = parts + (total ? sep + totalLabel + total : '');
-})();
-
-document.getElementById('copyBtn').addEventListener('click', async () => {
-  try {
-    await navigator.clipboard.writeText(location.href);
-    alert(LANG === 'en' ? 'Link copied.' : '已复制当前结果链接');
-  } catch (err) {
-    alert(LANG === 'en' ? 'Copy failed, please copy link manually' : '复制失败，请手动复制地址栏链接');
-  }
-});
+    initResult('explorer');
   </script>
 </body>
 </html>

--- a/results/organizer.html
+++ b/results/organizer.html
@@ -43,57 +43,9 @@
     <p>© 2025 Psychotest · 本测试仅供娱乐与自我反思。</p>
   </footer>
 
+  <script src="../results.js"></script>
   <script>
-const LANG = navigator.language && navigator.language.startsWith('en') ? 'en' : 'zh';
-document.documentElement.lang = LANG;
-
-if (LANG === 'en') {
-  document.title = 'Organizer (Orderly Executor) | Test Result';
-  document.querySelector('h1').textContent = 'Your Result';
-  document.querySelector('.result-type').innerHTML = 'Organizer (Orderly Executor)<span class="badge">Non-clinical · For fun</span>';
-  document.querySelector('.kv').innerHTML = 'Type code: <code>organizer</code>';
-  document.querySelectorAll('h3')[0].textContent = 'Your Strengths';
-  document.querySelectorAll('ul')[0].innerHTML = '<li>Skilled at goal breakdown, pacing, and progress tracking.</li><li>Stable and reliable, able to deliver complex projects.</li><li>Focuses on standards and quality with attention to detail.</li>';
-  document.querySelectorAll('h3')[1].textContent = 'Tips for You';
-  document.querySelectorAll('ul')[1].innerHTML = '<li>Avoid over-pursuing perfection; leave flexible buffers in plans.</li><li>Review periodically to ensure you focus on the most impactful 20%.</li><li>Work with "Explorers" to infuse innovation into processes.</li>';
-  document.querySelectorAll('h3')[2].textContent = 'Scores in Each Dimension';
-  document.getElementById('scores').textContent = 'Loading...';
-  document.querySelector('.btns a').textContent = 'Take Again';
-  document.getElementById('copyBtn').textContent = 'Copy Result Link';
-  document.querySelector('footer p').textContent = '© 2025 Psychotest · This test is for entertainment and self-reflection.';
-}
-
-(function () {
-  const p = new URLSearchParams(location.search);
-  const a = Number(p.get('analyst') || 0);
-  const e = Number(p.get('explorer') || 0);
-  const o = Number(p.get('organizer') || 0);
-  const c = Number(p.get('connector') || 0);
-  const labels = LANG === 'en'
-    ? { connector: 'Connector', explorer: 'Explorer', organizer: 'Organizer', analyst: 'Analyst' }
-    : { connector: '连接者', explorer: '探索者', organizer: '组织者', analyst: '分析者' };
-  const scores = [
-    [labels.connector, c],
-    [labels.explorer, e],
-    [labels.organizer, o],
-    [labels.analyst, a],
-  ];
-  const total = a + e + o + c;
-  const sep = LANG === 'en' ? ' | ' : ' ｜ ';
-  const colon = LANG === 'en' ? ': ' : '：';
-  const totalLabel = LANG === 'en' ? 'Total: ' : '总分：';
-  const parts = scores.map(([k, v]) => k + colon + v).join(sep);
-  document.getElementById('scores').textContent = parts + (total ? sep + totalLabel + total : '');
-})();
-
-document.getElementById('copyBtn').addEventListener('click', async () => {
-  try {
-    await navigator.clipboard.writeText(location.href);
-    alert(LANG === 'en' ? 'Link copied.' : '已复制当前结果链接');
-  } catch (err) {
-    alert(LANG === 'en' ? 'Copy failed, please copy link manually' : '复制失败，请手动复制地址栏链接');
-  }
-});
+    initResult('organizer');
   </script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,142 +1,5 @@
-// Language detection
-const LANG = navigator.language && navigator.language.startsWith('en') ? 'en' : 'zh';
-
-// UI text translations
-const UI = {
-  title: {
-    zh: '性格心理测试',
-    en: 'Personality Test',
-  },
-  subtitle: {
-    zh: '12 道题 · 约 2 分钟 · 本地计算，无需登录',
-    en: '12 questions · about 2 minutes · runs locally, no login required',
-  },
-  submit: {
-    zh: '提交并查看结果',
-    en: 'Submit & View Result',
-  },
-  reset: {
-    zh: '清空重做',
-    en: 'Reset',
-  },
-  disclaimer: {
-    zh: '* 免责声明：本测试仅供娱乐与自我反思，不构成临床或诊断建议。',
-    en: '* Disclaimer: This test is for entertainment and self-reflection only and is not clinical or diagnostic advice.',
-  },
-  legend: {
-    zh: n => `第 ${n} 题`,
-    en: n => `Question ${n}`,
-  },
-  unfinished: {
-    zh: n => `还有题目未作答（第 ${n} 题）`,
-    en: n => `Question ${n} is unanswered.`,
-  },
-};
-
-// ====== Question bank (12 items; 3 per dimension) ======
-const DIM_ORDER = ['connector', 'explorer', 'organizer', 'analyst'];
-
-const QUESTIONS = [
-  // connector ×3
-  {
-    text: {
-      zh: '在新的社交场合里，你通常能很快破冰并与人建立联系。',
-      en: 'In new social settings, you can quickly break the ice and connect with others.',
-    },
-    dim: 'connector',
-  },
-  {
-    text: {
-      zh: '遇到问题时，你更愿意和别人讨论，而不是独自思考。',
-      en: 'When facing problems, you prefer discussing with others rather than thinking alone.',
-    },
-    dim: 'connector',
-  },
-  {
-    text: {
-      zh: '你喜欢在群聊或会议中主动发起话题。',
-      en: 'You like to initiate topics in group chats or meetings.',
-    },
-    dim: 'connector',
-  },
-
-  // explorer ×3
-  {
-    text: {
-      zh: '你享受尝试全新的工具、方法或路径。',
-      en: 'You enjoy trying completely new tools, methods, or paths.',
-    },
-    dim: 'explorer',
-  },
-  {
-    text: {
-      zh: '面对未知或变化，你更多是兴奋而不是焦虑。',
-      en: 'When facing the unknown or change, you feel more excited than anxious.',
-    },
-    dim: 'explorer',
-  },
-  {
-    text: {
-      zh: '你喜欢临时起意的安排，例如说走就走的小旅行。',
-      en: 'You enjoy spur-of-the-moment plans, like spontaneous trips.',
-    },
-    dim: 'explorer',
-  },
-
-  // organizer ×3
-  {
-    text: {
-      zh: '你会把待办事项拆解并安排到日程里逐一推进。',
-      en: 'You break down to-do items and schedule them step by step.',
-    },
-    dim: 'organizer',
-  },
-  {
-    text: {
-      zh: '你更倾向于按计划一步步执行项目，少走捷径。',
-      en: 'You tend to follow plans step by step, avoiding shortcuts.',
-    },
-    dim: 'organizer',
-  },
-  {
-    text: {
-      zh: '临时改计划会让你不适，甚至有些反感。',
-      en: 'Last-minute changes to plans make you uncomfortable or even resentful.',
-    },
-    dim: 'organizer',
-  },
-
-  // analyst ×3
-  {
-    text: {
-      zh: '做重要决策前，你会先收集尽可能多的事实和数据。',
-      en: 'Before making important decisions, you gather as many facts and data as possible.',
-    },
-    dim: 'analyst',
-  },
-  {
-    text: {
-      zh: '你常用图表或数据来阐述观点。',
-      en: 'You often use charts or data to explain your ideas.',
-    },
-    dim: 'analyst',
-  },
-  {
-    text: {
-      zh: '对于未经验证的结论，你会保持质疑并寻求证据。',
-      en: 'You remain skeptical of unverified conclusions and seek evidence.',
-    },
-    dim: 'analyst',
-  },
-];
-
-const LIKERT = [
-  { value: 1, label: { zh: '非常不同意', en: 'Strongly disagree' } },
-  { value: 2, label: { zh: '不同意', en: 'Disagree' } },
-  { value: 3, label: { zh: '一般', en: 'Neutral' } },
-  { value: 4, label: { zh: '同意', en: 'Agree' } },
-  { value: 5, label: { zh: '非常同意', en: 'Strongly agree' } },
-];
+// Translation data is loaded from translations.js and provides
+// globals: LANG, UI, DIM_ORDER, QUESTIONS, LIKERT
 
 // ====== Render form ======
 function renderQuestions() {
@@ -235,12 +98,14 @@ function resetForm() {
 // ====== Init ======
 document.addEventListener('DOMContentLoaded', () => {
   document.documentElement.lang = LANG;
+  document.documentElement.dir = LANG === 'ar' ? 'rtl' : 'ltr';
   document.title = `${UI.title[LANG]}｜Psychotest`;
   document.getElementById('pageTitle').textContent = UI.title[LANG];
   document.getElementById('pageSub').textContent = UI.subtitle[LANG];
   document.getElementById('submitBtn').textContent = UI.submit[LANG];
   document.getElementById('resetBtn').textContent = UI.reset[LANG];
   document.getElementById('disclaimer').textContent = UI.disclaimer[LANG];
+  document.getElementById('copyright').textContent = UI.copyright[LANG];
 
   renderQuestions();
   document

--- a/style.css
+++ b/style.css
@@ -50,6 +50,7 @@ html{ -webkit-text-size-adjust:100%; }
 body{
   font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI",
                "PingFang SC","Hiragino Sans GB","Microsoft YaHei","Noto Sans SC",
+               "Noto Sans TC","Noto Sans JP","Noto Sans KR","Noto Naskh Arabic",
                "Helvetica Neue", Arial, "Apple Color Emoji","Segoe UI Emoji";
   background: var(--bg);
   color: var(--text);

--- a/translations.js
+++ b/translations.js
@@ -1,0 +1,315 @@
+// Language detection and translation data for index page
+const LANG = (() => {
+  const l = (navigator.language || 'en').toLowerCase();
+  if (l.startsWith('zh')) {
+    return /tw|hk|mo|hant/.test(l) ? 'zh-Hant' : 'zh';
+    }
+  if (l.startsWith('ja')) return 'ja';
+  if (l.startsWith('ko')) return 'ko';
+  if (l.startsWith('fr')) return 'fr';
+  if (l.startsWith('de')) return 'de';
+  if (l.startsWith('ar')) return 'ar';
+  if (l.startsWith('ru')) return 'ru';
+  if (l.startsWith('es')) return 'es';
+  return 'en';
+})();
+
+const UI = {
+  title: {
+    zh: '性格心理测试',
+    'zh-Hant': '性格心理測試',
+    en: 'Personality Test',
+    ja: '性格診断テスト',
+    ko: '성격 심리 테스트',
+    fr: 'Test de personnalité',
+    de: 'Persönlichkeitstest',
+    ar: 'اختبار الشخصية',
+    ru: 'Тест личности',
+    es: 'Prueba de personalidad',
+  },
+  subtitle: {
+    zh: '12 道题 · 约 2 分钟 · 本地计算，无需登录',
+    'zh-Hant': '12 道題 · 約 2 分鐘 · 本地計算，無需登入',
+    en: '12 questions · about 2 minutes · runs locally, no login required',
+    ja: '全12問・約2分・ローカル計算、ログイン不要',
+    ko: '문항 12개 · 약 2분 · 로컬 계산, 로그인 불필요',
+    fr: '12 questions · environ 2 minutes · calcul local, sans connexion',
+    de: '12 Fragen · ca. 2 Minuten · lokale Berechnung, keine Anmeldung erforderlich',
+    ar: '12 سؤالًا · حوالي دقيقتين · يعمل محليًا، لا حاجة لتسجيل الدخول',
+    ru: '12 вопросов · около 2 минут · локальный расчёт, без входа',
+    es: '12 preguntas · aproximadamente 2 minutos · se ejecuta localmente, sin iniciar sesión',
+  },
+  submit: {
+    zh: '提交并查看结果',
+    'zh-Hant': '提交並查看結果',
+    en: 'Submit & View Result',
+    ja: '結果を表示',
+    ko: '제출하고 결과 보기',
+    fr: 'Envoyer et voir le résultat',
+    de: 'Absenden & Ergebnis ansehen',
+    ar: 'إرسال وعرض النتيجة',
+    ru: 'Отправить и посмотреть результат',
+    es: 'Enviar y ver resultado',
+  },
+  reset: {
+    zh: '清空重做',
+    'zh-Hant': '清空重做',
+    en: 'Reset',
+    ja: 'リセット',
+    ko: '초기화',
+    fr: 'Réinitialiser',
+    de: 'Zurücksetzen',
+    ar: 'إعادة تعيين',
+    ru: 'Сбросить',
+    es: 'Reiniciar',
+  },
+  disclaimer: {
+    zh: '* 免责声明：本测试仅供娱乐与自我反思，不构成临床或诊断建议。',
+    'zh-Hant': '* 免責聲明：本測試僅供娛樂與自我反思，不構成臨床或診斷建議。',
+    en: '* Disclaimer: This test is for entertainment and self-reflection only and is not clinical or diagnostic advice.',
+    ja: '* 免責事項：本テストは娯楽と自己省察のみを目的とし、臨床的または診断的な助言ではありません。',
+    ko: '* 면책조항: 본 테스트는 오락 및 자기 성찰 용도로만 사용되며, 임상 또는 진단 조언이 아닙니다.',
+    fr: '* Avertissement : ce test est destiné au divertissement et à l’auto-réflexion uniquement et ne constitue pas un avis clinique ou diagnostique.',
+    de: '* Haftungsausschluss: Dieser Test dient nur der Unterhaltung und Selbstreflexion und stellt keine klinische oder diagnostische Beratung dar.',
+    ar: '* إخلاء المسؤولية: هذا الاختبار للترفيه والتأمل الذاتي فقط ولا يُعد نصيحة طبية أو تشخيصية.',
+    ru: '* Отказ от ответственности: этот тест предназначен только для развлечения и самоанализа и не является клинической или диагностической рекомендацией.',
+    es: '* Aviso: esta prueba es solo para entretenimiento y auto-reflexión y no constituye consejo clínico ni diagnóstico.',
+  },
+  legend: {
+    zh: n => `第 ${n} 题`,
+    'zh-Hant': n => `第 ${n} 題`,
+    en: n => `Question ${n}`,
+    ja: n => `${n}問目`,
+    ko: n => `${n}번 문제`,
+    fr: n => `Question ${n}`,
+    de: n => `Frage ${n}`,
+    ar: n => `السؤال ${n}`,
+    ru: n => `Вопрос ${n}`,
+    es: n => `Pregunta ${n}`,
+  },
+  unfinished: {
+    zh: n => `还有题目未作答（第 ${n} 题）`,
+    'zh-Hant': n => `還有題目未作答（第 ${n} 題）`,
+    en: n => `Question ${n} is unanswered.`,
+    ja: n => `${n}問目が未回答です。`,
+    ko: n => `${n}번 문항이 답변되지 않았습니다.`,
+    fr: n => `La question ${n} n’est pas remplie.`,
+    de: n => `Frage ${n} ist unbeantwortet.`,
+    ar: n => `السؤال ${n} لم يتم الإجابة عليه.`,
+    ru: n => `Вопрос ${n} не отвечен.`,
+    es: n => `La pregunta ${n} no está respondida.`,
+  },
+  copyright: {
+    zh: '© 2025 Psychotest',
+    'zh-Hant': '© 2025 Psychotest',
+    en: '© 2025 Psychotest',
+    ja: '© 2025 Psychotest',
+    ko: '© 2025 Psychotest',
+    fr: '© 2025 Psychotest',
+    de: '© 2025 Psychotest',
+    ar: '© 2025 Psychotest',
+    ru: '© 2025 Psychotest',
+    es: '© 2025 Psychotest',
+  },
+};
+
+const DIM_ORDER = ['connector', 'explorer', 'organizer', 'analyst'];
+
+const QUESTIONS = [
+  // connector ×3
+  {
+    text: {
+      zh: '在新的社交场合里，你通常能很快破冰并与人建立联系。',
+      'zh-Hant': '在新的社交場合裡，你通常能很快破冰並與人建立連結。',
+      en: 'In new social settings, you can quickly break the ice and connect with others.',
+      ja: '新しい社交の場で、あなたはすばやく打ち解けて他人とつながることができる。',
+      ko: '새로운 사회적 상황에서 당신은 빠르게 어색함을 깨고 사람들과 연결될 수 있다.',
+      fr: 'Dans un nouvel environnement social, vous brisez rapidement la glace et vous liez aux autres.',
+      de: 'In neuen sozialen Situationen kannst du schnell das Eis brechen und Kontakte knüpfen.',
+      ar: 'في المواقف الاجتماعية الجديدة، يمكنك كسر الجليد بسرعة وبناء علاقات مع الآخرين.',
+      ru: 'В новых социальных ситуациях вы быстро находите общий язык и устанавливаете связи с другими.',
+      es: 'En nuevos entornos sociales, puedes romper el hielo rápidamente y conectar con los demás.',
+    },
+    dim: 'connector',
+  },
+  {
+    text: {
+      zh: '遇到问题时，你更愿意和别人讨论，而不是独自思考。',
+      'zh-Hant': '遇到問題時，你更願意和別人討論，而不是獨自思考。',
+      en: 'When facing problems, you prefer discussing with others rather than thinking alone.',
+      ja: '問題に直面したとき、独りで考えるよりも他人と話し合うことを好む。',
+      ko: '문제에 직면하면 혼자 고민하기보다 다른 사람과 토론하는 것을 선호한다.',
+      fr: 'Face à un problème, vous préférez en discuter avec d’autres plutôt que de réfléchir seul.',
+      de: 'Wenn du vor Problemen stehst, diskutierst du lieber mit anderen, statt allein nachzudenken.',
+      ar: 'عندما تواجه مشكلة، تفضّل مناقشتها مع الآخرين بدلاً من التفكير وحدك.',
+      ru: 'Столкнувшись с проблемой, вы предпочитаете обсудить её с другими, а не думать в одиночку.',
+      es: 'Cuando enfrentas problemas, prefieres discutirlos con otros en lugar de pensar solo.',
+    },
+    dim: 'connector',
+  },
+  {
+    text: {
+      zh: '你喜欢在群聊或会议中主动发起话题。',
+      'zh-Hant': '你喜歡在群聊或會議中主動發起話題。',
+      en: 'You like to initiate topics in group chats or meetings.',
+      ja: 'グループチャットや会議で積極的に話題を振るのが好きだ。',
+      ko: '단체 채팅이나 회의에서 주제를 먼저 꺼내는 것을 좋아한다.',
+      fr: 'Vous aimez lancer des sujets dans les discussions de groupe ou les réunions.',
+      de: 'In Gruppenchats oder Besprechungen bringst du gerne Themen ein.',
+      ar: 'تحب أن تبدأ المواضيع في الدردشات الجماعية أو الاجتماعات.',
+      ru: 'В групповых чатах или на встречах вам нравится начинать обсуждения.',
+      es: 'Te gusta iniciar temas en los chats grupales o reuniones.',
+    },
+    dim: 'connector',
+  },
+
+  // explorer ×3
+  {
+    text: {
+      zh: '你享受尝试全新的工具、方法或路径。',
+      'zh-Hant': '你享受嘗試全新的工具、方法或路徑。',
+      en: 'You enjoy trying completely new tools, methods, or paths.',
+      ja: 'まったく新しいツールや方法、道を試すのを楽しむ。',
+      ko: '완전히 새로운 도구, 방법, 또는 길을 시도하는 것을 즐긴다.',
+      fr: 'Vous aimez essayer des outils, méthodes ou chemins totalement nouveaux.',
+      de: 'Du probierst gern völlig neue Werkzeuge, Methoden oder Wege aus.',
+      ar: 'تستمتع بتجربة أدوات أو طرق أو مسارات جديدة تمامًا.',
+      ru: 'Вы с удовольствием пробуете совершенно новые инструменты, методы или пути.',
+      es: 'Disfrutas probar herramientas, métodos o caminos completamente nuevos.',
+    },
+    dim: 'explorer',
+  },
+  {
+    text: {
+      zh: '面对未知或变化，你更多是兴奋而不是焦虑。',
+      'zh-Hant': '面對未知或變化，你更多是興奮而不是焦慮。',
+      en: 'When facing the unknown or change, you feel more excited than anxious.',
+      ja: '未知や変化に直面したとき、不安よりもワクワクする。',
+      ko: '미지나 변화에 직면하면 불안보다 기대감이 더 크다.',
+      fr: 'Face à l’inconnu ou au changement, vous ressentez plus d’excitation que d’anxiété.',
+      de: 'Wenn du dem Unbekannten oder Veränderungen begegnest, bist du eher aufgeregt als ängstlich.',
+      ar: 'عندما تواجه المجهول أو التغيير، تشعر بالحماس أكثر من القلق.',
+      ru: 'Столкнувшись с неизвестностью или переменами, вы больше возбуждены, чем обеспокоены.',
+      es: 'Cuando te enfrentas a lo desconocido o a cambios, sientes más emoción que ansiedad.',
+    },
+    dim: 'explorer',
+  },
+  {
+    text: {
+      zh: '你喜欢临时起意的安排，例如说走就走的小旅行。',
+      'zh-Hant': '你喜歡臨時起意的安排，例如說走就走的小旅行。',
+      en: 'You enjoy spur-of-the-moment plans, like spontaneous trips.',
+      ja: '思いつきでの計画、例えば衝動的な小旅行などを楽しむ。',
+      ko: '충동적으로 떠나는 여행처럼 즉흥적인 계획을 즐긴다.',
+      fr: 'Vous appréciez les plans improvisés, comme les voyages spontanés.',
+      de: 'Du magst spontane Pläne, etwa eine kurzfristige Reise.',
+      ar: 'تستمتع بالخطط المفاجئة، مثل الرحلات العفوية.',
+      ru: 'Вам нравятся спонтанные планы, например, внезапные поездки.',
+      es: 'Disfrutas de planes espontáneos, como viajes improvisados.',
+    },
+    dim: 'explorer',
+  },
+
+  // organizer ×3
+  {
+    text: {
+      zh: '你会把待办事项拆解并安排到日程里逐一推进。',
+      'zh-Hant': '你會把待辦事項拆解並安排到日程裡逐一推進。',
+      en: 'You break down to-do items and schedule them step by step.',
+      ja: 'やるべきことを細分化し、スケジュールに沿って一つずつ進める。',
+      ko: '할 일을 세분화하여 일정에 맞춰 하나씩 진행한다.',
+      fr: 'Vous décomposez les tâches à faire et les planifiez étape par étape.',
+      de: 'Du zerlegst Aufgaben und planst sie Schritt für Schritt.',
+      ar: 'تقسّم المهام وتجدولها خطوة بخطوة.',
+      ru: 'Вы разбиваете задачи на этапы и планируете их шаг за шагом.',
+      es: 'Desglosas las tareas y las programas paso a paso.',
+    },
+    dim: 'organizer',
+  },
+  {
+    text: {
+      zh: '你更倾向于按计划一步步执行项目，少走捷径。',
+      'zh-Hant': '你更傾向於按計劃一步步執行項目，少走捷徑。',
+      en: 'You tend to follow plans step by step, avoiding shortcuts.',
+      ja: '近道を避け、計画に沿って一歩ずつ進める傾向がある。',
+      ko: '지름길을 피하고 계획대로 한 단계씩 진행하는 편이다.',
+      fr: 'Vous avez tendance à suivre les plans étape par étape, en évitant les raccourcis.',
+      de: 'Du neigst dazu, Pläne Schritt für Schritt umzusetzen und Abkürzungen zu vermeiden.',
+      ar: 'تميل إلى تنفيذ الخطط خطوة بخطوة، متجنبًا الطرق المختصرة.',
+      ru: 'Вы склонны следовать плану шаг за шагом, избегая коротких путей.',
+      es: 'Tiendes a seguir los planes paso a paso, evitando atajos.',
+    },
+    dim: 'organizer',
+  },
+  {
+    text: {
+      zh: '临时改计划会让你不适，甚至有些反感。',
+      'zh-Hant': '臨時改計劃會讓你不適，甚至有些反感。',
+      en: 'Last-minute changes to plans make you uncomfortable or even resentful.',
+      ja: '直前の計画変更は不快、場合によっては反感を覚える。',
+      ko: '계획이 갑자기 바뀌면 불편하거나 심지어 불쾌해진다.',
+      fr: 'Les changements de plan de dernière minute vous mettent mal à l’aise, voire vous agacent.',
+      de: 'Spontane Planänderungen sind dir unangenehm, manchmal sogar lästig.',
+      ar: 'التغييرات المفاجئة في الخطة تجعلك غير مرتاح أو حتى منزعجًا.',
+      ru: 'Внезапные изменения планов вызывают у вас дискомфорт или даже раздражение.',
+      es: 'Los cambios de planes de última hora te incomodan o incluso te molestan.',
+    },
+    dim: 'organizer',
+  },
+
+  // analyst ×3
+  {
+    text: {
+      zh: '做重要决策前，你会先收集尽可能多的事实和数据。',
+      'zh-Hant': '做重要決策前，你會先收集盡可能多的事實和數據。',
+      en: 'Before making important decisions, you gather as many facts and data as possible.',
+      ja: '重要な決断を下す前に、できるだけ多くの事実とデータを集める。',
+      ko: '중요한 결정을 내리기 전에 가능한 많은 사실과 데이터를 수집한다.',
+      fr: 'Avant de prendre une décision importante, vous rassemblez autant de faits et de données que possible.',
+      de: 'Bevor du wichtige Entscheidungen triffst, sammelst du so viele Fakten und Daten wie möglich.',
+      ar: 'قبل اتخاذ قرارات مهمة، تجمع أكبر قدر ممكن من الحقائق والبيانات.',
+      ru: 'Прежде чем принять важное решение, вы собираете как можно больше фактов и данных.',
+      es: 'Antes de tomar decisiones importantes, recopilas tantos hechos y datos como sea posible.',
+    },
+    dim: 'analyst',
+  },
+  {
+    text: {
+      zh: '你常用图表或数据来阐述观点。',
+      'zh-Hant': '你常用圖表或數據來闡述觀點。',
+      en: 'You often use charts or data to explain your ideas.',
+      ja: '考えを説明するために、よくグラフやデータを用いる。',
+      ko: '생각을 설명할 때 차트나 데이터를 자주 활용한다.',
+      fr: 'Vous utilisez souvent des graphiques ou des données pour expliquer vos idées.',
+      de: 'Du nutzt häufig Diagramme oder Daten, um deine Ideen zu erklären.',
+      ar: 'غالبًا ما تستخدم الرسوم البيانية أو البيانات لشرح أفكارك.',
+      ru: 'Вы часто используете графики или данные, чтобы объяснить свои идеи.',
+      es: 'A menudo usas gráficos o datos para explicar tus ideas.',
+    },
+    dim: 'analyst',
+  },
+  {
+    text: {
+      zh: '对于未经验证的结论，你会保持质疑并寻求证据。',
+      'zh-Hant': '對於未經驗證的結論，你會保持質疑並尋求證據。',
+      en: 'You remain skeptical of unverified conclusions and seek evidence.',
+      ja: '裏付けのない結論には懐疑的で、証拠を求める。',
+      ko: '검증되지 않은 결론에 회의적이며 증거를 찾는다.',
+      fr: 'Vous restez sceptique face aux conclusions non vérifiées et recherchez des preuves.',
+      de: 'Unbestätigten Schlussfolgerungen stehst du skeptisch gegenüber und suchst nach Beweisen.',
+      ar: 'تبقى متشككًا في الاستنتاجات غير المثبتة وتبحث عن الأدلة.',
+      ru: 'Вы скептически относитесь к непроверенным выводам и ищете доказательства.',
+      es: 'Te mantienes escéptico ante conclusiones no verificadas y buscas evidencia.',
+    },
+    dim: 'analyst',
+  },
+];
+
+const LIKERT = [
+  { value: 1, label: { zh: '非常不同意', 'zh-Hant': '非常不同意', en: 'Strongly disagree', ja: 'まったくそう思わない', ko: '전혀 동의하지 않음', fr: 'Tout à fait en désaccord', de: 'Stimme überhaupt nicht zu', ar: 'أعارض بشدة', ru: 'Совершенно не согласен', es: 'Totalmente en desacuerdo' } },
+  { value: 2, label: { zh: '不同意', 'zh-Hant': '不同意', en: 'Disagree', ja: 'そう思わない', ko: '동의하지 않음', fr: 'Pas d’accord', de: 'Stimme nicht zu', ar: 'أعارض', ru: 'Не согласен', es: 'En desacuerdo' } },
+  { value: 3, label: { zh: '一般', 'zh-Hant': '一般', en: 'Neutral', ja: 'どちらでもない', ko: '보통', fr: 'Neutre', de: 'Neutral', ar: 'محايد', ru: 'Нейтрально', es: 'Neutral' } },
+  { value: 4, label: { zh: '同意', 'zh-Hant': '同意', en: 'Agree', ja: 'そう思う', ko: '동의함', fr: 'D’accord', de: 'Stimme zu', ar: 'أوافق', ru: 'Согласен', es: 'De acuerdo' } },
+  { value: 5, label: { zh: '非常同意', 'zh-Hant': '非常同意', en: 'Strongly agree', ja: 'とてもそう思う', ko: '매우 동의함', fr: 'Tout à fait d’accord', de: 'Stimme voll zu', ar: 'أوافق بشدة', ru: 'Полностью согласен', es: 'Totalmente de acuerdo' } },
+];
+


### PR DESCRIPTION
## Summary
- extend personality test with Japanese, Korean, French, Traditional Chinese, German, Arabic, Russian, and Spanish translations
- centralize translations and rendering for result pages
- add extra fonts and RTL support for Arabic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898ecf23d348333b6af3b216271d24d