### PR TITLE
Update Google AdSense ID across pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,9 +22,9 @@
   }
   </script>
   <link rel="stylesheet" href="style.css" />
-  <meta name="google-adsense-account" content="ca-pub-1357481496968248">
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1357481496968248"
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4237167791029601"
      crossorigin="anonymous"></script>
+  <meta name="google-adsense-account" content="ca-pub-4237167791029601">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-9PTHZ0E7NE"></script>
   <script>

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
   <meta property="og:type" content="website" />
   <meta property="og:locale" content="zh_CN" />
   <link rel="stylesheet" href="style.css" />
-  <meta name="google-adsense-account" content="ca-pub-1357481496968248">
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1357481496968248" crossorigin="anonymous"></script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4237167791029601" crossorigin="anonymous"></script>
+  <meta name="google-adsense-account" content="ca-pub-4237167791029601">
 </head>
 <body data-page="privacy">
   <header class="container">

--- a/results/analyst.html
+++ b/results/analyst.html
@@ -21,9 +21,9 @@
     "inLanguage": "zh-CN"
   }
   </script>
-  <meta name="google-adsense-account" content="ca-pub-1357481496968248">
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1357481496968248"
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4237167791029601"
     crossorigin="anonymous"></script>
+  <meta name="google-adsense-account" content="ca-pub-4237167791029601">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-9PTHZ0E7NE"></script>
   <script>

--- a/results/connector.html
+++ b/results/connector.html
@@ -21,9 +21,9 @@
     "inLanguage": "zh-CN"
   }
   </script>
-  <meta name="google-adsense-account" content="ca-pub-1357481496968248">
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1357481496968248"
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4237167791029601"
     crossorigin="anonymous"></script>
+  <meta name="google-adsense-account" content="ca-pub-4237167791029601">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-9PTHZ0E7NE"></script>
   <script>

--- a/results/explorer.html
+++ b/results/explorer.html
@@ -21,9 +21,9 @@
     "inLanguage": "zh-CN"
   }
   </script>
-  <meta name="google-adsense-account" content="ca-pub-1357481496968248">
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1357481496968248"
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4237167791029601"
     crossorigin="anonymous"></script>
+  <meta name="google-adsense-account" content="ca-pub-4237167791029601">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-9PTHZ0E7NE"></script>
   <script>

--- a/results/organizer.html
+++ b/results/organizer.html
@@ -21,9 +21,9 @@
     "inLanguage": "zh-CN"
   }
   </script>
-  <meta name="google-adsense-account" content="ca-pub-1357481496968248">
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1357481496968248"
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4237167791029601"
     crossorigin="anonymous"></script>
+  <meta name="google-adsense-account" content="ca-pub-4237167791029601">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-9PTHZ0E7NE"></script>
   <script>

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
   <meta property="og:type" content="website" />
   <meta property="og:locale" content="zh_CN" />
   <link rel="stylesheet" href="style.css" />
-  <meta name="google-adsense-account" content="ca-pub-1357481496968248">
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1357481496968248" crossorigin="anonymous"></script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4237167791029601" crossorigin="anonymous"></script>
+  <meta name="google-adsense-account" content="ca-pub-4237167791029601">
 </head>
 <body data-page="terms">
   <header class="container">


### PR DESCRIPTION
## Summary
- replace legacy AdSense script and meta tags with new client ID `ca-pub-4237167791029601`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899d7b058bc8333bc5ca1e869273265