### PR TITLE
Add Italian language support

### DIFF
--- a/legal.js
+++ b/legal.js
@@ -10,6 +10,7 @@ const LANG = (() => {
   if (l.startsWith('de')) return 'de';
   if (l.startsWith('ar')) return 'ar';
   if (l.startsWith('ru')) return 'ru';
+  if (l.startsWith('it')) return 'it';
   if (l.startsWith('es')) return 'es';
   return 'en';
 })();
@@ -27,6 +28,7 @@ const LEGAL = {
       ar: 'سياسة الخصوصية',
       ru: 'Политика конфиденциальности',
       es: 'Política de privacidad',
+      it: 'Informativa sulla privacy',
     },
     terms: {
       zh: '服务条款',
@@ -39,6 +41,7 @@ const LEGAL = {
       ar: 'شروط الخدمة',
       ru: 'Условия использования',
       es: 'Términos del servicio',
+      it: 'Termini di servizio',
     },
   },
   copyright: {
@@ -52,6 +55,7 @@ const LEGAL = {
     ar: '© 2025 Psychotest',
     ru: '© 2025 Psychotest',
     es: '© 2025 Psychotest',
+    it: '© 2025 Psychotest',
   },
   privacy: {
     title: {
@@ -65,6 +69,7 @@ const LEGAL = {
       ar: 'سياسة الخصوصية',
       ru: 'Политика конфиденциальности',
       es: 'Política de privacidad',
+      it: 'Informativa sulla privacy',
     },
     content: {
       zh: '<p>我们尊重您的隐私。本网站不收集可识别个人身份的信息。广告和分析可能会使用 Cookie。</p><p>使用本网站即表示您同意谷歌及其他第三方按照其政策处理数据。</p>',
@@ -77,6 +82,7 @@ const LEGAL = {
       ar: '<p>نحن نحترم خصوصيتك. هذا الموقع لا يجمع معلومات شخصية يمكن التعرف عليها. قد تستخدم الإعلانات والتحليلات ملفات تعريف الارتباط.</p><p>باستخدامك لهذا الموقع فإنك توافق على ممارسات البيانات لدى Google والجهات الأخرى.</p>',
       ru: '<p>Мы уважаем вашу конфиденциальность. Этот сайт не собирает персональные данные. Реклама и аналитика могут использовать cookies.</p><p>Используя сайт, вы соглашаетесь с правилами обработки данных Google и других сторон.</p>',
       es: '<p>Respetamos tu privacidad. Este sitio no recopila información personal identificable. Los anuncios y la analítica pueden usar cookies.</p><p>Al usar este sitio, aceptas las prácticas de datos de Google y otros terceros.</p>',
+      it: '<p>Rispettiamo la tua privacy. Questo sito non raccoglie informazioni personali identificabili. Gli annunci e le analisi possono utilizzare cookie.</p><p>Utilizzando questo sito, accetti le pratiche sui dati di Google e di altre terze parti.</p>',
     },
   },
   terms: {
@@ -91,6 +97,7 @@ const LEGAL = {
       ar: 'شروط الخدمة',
       ru: 'Условия использования',
       es: 'Términos del servicio',
+      it: 'Termini di servizio',
     },
     content: {
       zh: '<p>使用本网站即表示您同意这些条款。本测试仅供娱乐，不构成专业建议。</p><p>我们不对因使用本网站而产生的任何损失负责。</p>',
@@ -103,6 +110,7 @@ const LEGAL = {
       ar: '<p>باستخدامك لهذا الموقع فإنك توافق على هذه الشروط. هذا الاختبار للترفيه فقط وليس نصيحة مهنية.</p><p>نحن غير مسؤولين عن أي أضرار ناتجة عن استخدام هذا الموقع.</p>',
       ru: '<p>Используя сайт, вы соглашаетесь с этими условиями. Тест предназначен только для развлечения и не является профессиональным советом.</p><p>Мы не несем ответственности за какой-либо ущерб, возникший из-за использования сайта.</p>',
       es: '<p>Al usar este sitio, aceptas estos términos. La prueba es solo para entretenimiento y no constituye asesoramiento profesional.</p><p>No somos responsables de los daños derivados del uso de este sitio.</p>',
+      it: '<p>Utilizzando questo sito accetti questi termini. Il test è solo a scopo di intrattenimento e non costituisce consulenza professionale.</p><p>Non siamo responsabili per eventuali danni derivanti dall\'uso di questo sito.</p>',
     },
   },
 };

--- a/results.js
+++ b/results.js
@@ -10,6 +10,7 @@ function detectLang() {
   if (l.startsWith('de')) return 'de';
   if (l.startsWith('ar')) return 'ar';
   if (l.startsWith('ru')) return 'ru';
+  if (l.startsWith('it')) return 'it';
   if (l.startsWith('es')) return 'es';
   return 'en';
 }
@@ -179,6 +180,22 @@ const RES_UI = {
     colon: ': ',
     totalLabel: 'Total: ',
   },
+  it: {
+    header: 'Il tuo risultato',
+    strengthsTitle: 'I tuoi punti di forza',
+    tipsTitle: 'Suggerimenti per te',
+    scoresTitle: 'Punteggi per ogni dimensione',
+    loading: 'Caricamento...',
+    again: 'Ripeti il test',
+    copy: 'Copia il link del risultato',
+    footer: '© 2025 Psychotest · <a href="../privacy.html">Informativa sulla privacy</a> · <a href="../terms.html">Termini di servizio</a> · Questo test è solo per intrattenimento e auto-riflessione.',
+    copySuccess: 'Link copiato.',
+    copyFail: 'Copia non riuscita, per favore copia manualmente il link',
+    labels: { connector: 'Connettore', explorer: 'Esploratore', organizer: 'Organizzatore', analyst: 'Analista' },
+    sep: ' | ',
+    colon: ': ',
+    totalLabel: 'Totale: ',
+  },
 };
 
 const RES_CONTENT = {
@@ -194,6 +211,7 @@ const RES_CONTENT = {
       ar: 'الموصِل (مدفوع اجتماعيًا) | نتيجة الاختبار',
       ru: 'Коммуникатор (социально ориентированный) | Результат теста',
       es: 'Conector (Impulsado por lo social) | Resultado del test',
+      it: 'Connettore (orientato al sociale) | Risultato del test',
     },
     resultType: {
       zh: '连接者（社交驱动）<span class="badge">非临床 · 娱乐向</span>',
@@ -206,6 +224,7 @@ const RES_CONTENT = {
       ar: 'الموصِل (مدفوع اجتماعيًا)<span class="badge">غير سريري · للمتعة</span>',
       ru: 'Коммуникатор (социально ориентированный)<span class="badge">Неклинический · Для развлечения</span>',
       es: 'Conector (Impulsado por lo social)<span class="badge">No clínico · Con fines recreativos</span>',
+      it: 'Connettore (orientato al sociale)<span class="badge">Non clinico · Per divertimento</span>',
     },
     kv: {
       zh: '类型代号：<code>connector</code>',
@@ -218,6 +237,7 @@ const RES_CONTENT = {
       ar: 'رمز النوع: <code>connector</code>',
       ru: 'Код типа: <code>connector</code>',
       es: 'Código de tipo: <code>connector</code>',
+      it: 'Codice tipo: <code>connector</code>',
     },
     strengths: {
       zh: [
@@ -269,6 +289,11 @@ const RES_CONTENT = {
         'Destacas en la comunicación y la colaboración, construyendo rápidamente confianza y empatía.',
         'Potencia a los demás en el equipo, facilitando el flujo de información y el consenso.',
         'Hábil en integrar recursos e impulsar proyectos entre departamentos.',
+      ],
+      it: [
+        'Abile nella comunicazione e collaborazione, costruisce rapidamente fiducia e intesa.',
+        'Nel team potenzia gli altri facilitando il flusso di informazioni e il raggiungimento del consenso.',
+        'Bravo a integrare risorse e a far avanzare progetti trasversali ai reparti.',
       ],
     },
     tips: {
@@ -322,6 +347,11 @@ const RES_CONTENT = {
         'Aprende a rechazar educadamente las solicitudes de baja prioridad para proteger tu tiempo de trabajo profundo.',
         'Colabora con «Analistas» para respaldar tus ideas con datos y aumentar la persuasión.',
       ],
+      it: [
+        'Per i compiti complessi crea checklist e tabelle di ritmo per evitare di “parlare molto e fare poco”.',
+        'Impara a rifiutare cortesemente le richieste a bassa priorità per proteggere il tempo di lavoro profondo.',
+        'Collabora con gli “Analisti” per supportare le idee con dati e aumentarne la forza persuasiva.',
+      ],
     },
   },
 
@@ -337,6 +367,7 @@ const RES_CONTENT = {
       ar: 'المستكشف (فضولي ومبتكر) | نتيجة الاختبار',
       ru: 'Исследователь (любопытный новатор) | Результат теста',
       es: 'Explorador (Curioso e innovador) | Resultado del test',
+      it: 'Esploratore (curioso e innovatore) | Risultato del test',
     },
     resultType: {
       zh: '探索者（好奇创新）<span class="badge">非临床 · 娱乐向</span>',
@@ -349,6 +380,7 @@ const RES_CONTENT = {
       ar: 'المستكشف (فضولي ومبتكر)<span class="badge">غير سريري · للمتعة</span>',
       ru: 'Исследователь (любопытный новатор)<span class="badge">Неклинический · Для развлечения</span>',
       es: 'Explorador (Curioso e innovador)<span class="badge">No clínico · Con fines recreativos</span>',
+      it: 'Esploratore (curioso e innovatore)<span class="badge">Non clinico · Per divertimento</span>',
     },
     kv: {
       zh: '类型代号：<code>explorer</code>',
@@ -361,6 +393,7 @@ const RES_CONTENT = {
       ar: 'رمز النوع: <code>explorer</code>',
       ru: 'Код типа: <code>explorer</code>',
       es: 'Código de tipo: <code>explorer</code>',
+      it: 'Codice tipo: <code>explorer</code>',
     },
     strengths: {
       zh: [
@@ -412,6 +445,11 @@ const RES_CONTENT = {
         'Sensibilizado a lo nuevo y rápido en el ensayo y error para encontrar soluciones innovadoras.',
         'Creativo y hábil para plantear preguntas desde diferentes perspectivas.',
         'Se adapta rápidamente al cambio y acepta la incertidumbre.',
+      ],
+      it: [
+        'Sensibile alle novità e rapido nel provare e sbagliare per trovare punti di svolta.',
+        'Creativo e bravo a porre domande da prospettive diverse.',
+        'Si adatta velocemente ai cambiamenti e abbraccia l\'incertezza.',
       ],
     },
     tips: {
@@ -465,6 +503,11 @@ const RES_CONTENT = {
         'Convierte las inspiraciones en plantillas reutilizables o procedimientos estándar (SOP).',
         'Colabora con «Organizadores» para convertir ideas en planes ejecutables.',
       ],
+      it: [
+        'Definisci i confini di ogni esperimento: obiettivi, tempo, metriche e criteri di uscita.',
+        'Trasforma le ispirazioni in modelli o procedure operative standard riutilizzabili.',
+        'Collabora con gli “Organizzatori” per trasformare le idee in piani attuabili.',
+      ],
     },
   },
 
@@ -480,6 +523,7 @@ const RES_CONTENT = {
       ar: 'المنظِّم (تنفيذ منظم) | نتيجة الاختبار',
       ru: 'Организатор (упорядоченный исполнитель) | Результат теста',
       es: 'Organizador (Ejecución ordenada) | Resultado del test',
+      it: 'Organizzatore (esecutore ordinato) | Risultato del test',
     },
     resultType: {
       zh: '组织者（有序执行）<span class="badge">非临床 · 娱乐向</span>',
@@ -492,6 +536,7 @@ const RES_CONTENT = {
       ar: 'المنظِّم (تنفيذ منظم)<span class="badge">غير سريري · للمتعة</span>',
       ru: 'Организатор (упорядоченный исполнитель)<span class="badge">Неклинический · Для развлечения</span>',
       es: 'Organizador (Ejecución ordenada)<span class="badge">No clínico · Con fines recreativos</span>',
+      it: 'Organizzatore (esecutore ordinato)<span class="badge">Non clinico · Per divertimento</span>',
     },
     kv: {
       zh: '类型代号：<code>organizer</code>',
@@ -504,6 +549,7 @@ const RES_CONTENT = {
       ar: 'رمز النوع: <code>organizer</code>',
       ru: 'Код типа: <code>organizer</code>',
       es: 'Código de tipo: <code>organizer</code>',
+      it: 'Codice tipo: <code>organizer</code>',
     },
     strengths: {
       zh: [
@@ -555,6 +601,11 @@ const RES_CONTENT = {
         'Hábil en descomponer objetivos, gestionar el ritmo y hacer seguimiento del progreso.',
         'Estable y confiable, capaz de llevar a cabo proyectos complejos.',
         'Se enfoca en las normas y la calidad, cuidando los detalles.',
+      ],
+      it: [
+        'Abile nella scomposizione degli obiettivi, nella gestione del ritmo e nel monitoraggio dei progressi.',
+        'Stabile e affidabile, capace di concretizzare progetti complessi.',
+        'Attento alle norme e alla qualità, con grande cura per i dettagli.',
       ],
     },
     tips: {
@@ -608,6 +659,11 @@ const RES_CONTENT = {
         'Revisa periódicamente para asegurarte de centrarte en el 20 % con mayor impacto.',
         'Colabora con «Exploradores» para inyectar innovación en los procesos.',
       ],
+      it: [
+        'Evita di perseguire troppo la perfezione; lascia margini flessibili nei piani.',
+        'Rivedi regolarmente per assicurarti di concentrarti sul 20% con il maggiore impatto.',
+        'Collabora con gli “Esploratori” per infondere innovazione nei processi.',
+      ],
     },
   },
 
@@ -623,6 +679,7 @@ const RES_CONTENT = {
       ar: 'المحلل (مدفوع بالبيانات) | نتيجة الاختبار',
       ru: 'Аналитик (ориентированный на данные) | Результат теста',
       es: 'Analista (Orientado a los datos) | Resultado del test',
+      it: 'Analista (guidato dai dati) | Risultato del test',
     },
     resultType: {
       zh: '分析者（数据理性）<span class="badge">非临床 · 娱乐向</span>',
@@ -635,6 +692,7 @@ const RES_CONTENT = {
       ar: 'المحلل (مدفوع بالبيانات)<span class="badge">غير سريري · للمتعة</span>',
       ru: 'Аналитик (ориентированный на данные)<span class="badge">Неклинический · Для развлечения</span>',
       es: 'Analista (Orientado a los datos)<span class="badge">No clínico · Con fines recreativos</span>',
+      it: 'Analista (guidato dai dati)<span class="badge">Non clinico · Per divertimento</span>',
     },
     kv: {
       zh: '类型代号：<code>analyst</code>',
@@ -647,6 +705,7 @@ const RES_CONTENT = {
       ar: 'رمز النوع: <code>analyst</code>',
       ru: 'Код типа: <code>analyst</code>',
       es: 'Código de tipo: <code>analyst</code>',
+      it: 'Codice tipo: <code>analyst</code>',
     },
     strengths: {
       zh: [
@@ -699,6 +758,11 @@ const RES_CONTENT = {
         'Hábil en utilizar modelos y datos para revelar los problemas esenciales.',
         'Bueno construyendo sistemas de evaluación y optimizándolos continuamente.',
       ],
+      it: [
+        'Orientato alle prove, con ragionamenti rigorosi e giudizio solido.',
+        "Abile nell'usare modelli e dati per rivelare i problemi fondamentali.",
+        'Capace di costruire sistemi di valutazione e di ottimizzarli continuamente.',
+      ],
     },
     tips: {
       zh: [
@@ -750,6 +814,11 @@ const RES_CONTENT = {
         'Cuidado con la «parálisis por análisis»; establece puntos claros de decisión.',
         'Co-crea con socios de negocio para que los informes conduzcan a acciones.',
         'Colabora con «Conectores» para traducir las ideas en un lenguaje comprensible y accionable.',
+      ],
+      it: [
+        'Attenzione alla “paralisi da analisi”; stabilisci punti decisionali chiari.',
+        'Cocrea con i partner di business per fare in modo che i report portino ad azioni.',
+        'Collabora con i “Connettori” per tradurre gli insight in un linguaggio comprensibile e attuabile.',
       ],
     },
   },

--- a/translations.js
+++ b/translations.js
@@ -10,6 +10,7 @@ const LANG = (() => {
   if (l.startsWith('de')) return 'de';
   if (l.startsWith('ar')) return 'ar';
   if (l.startsWith('ru')) return 'ru';
+  if (l.startsWith('it')) return 'it';
   if (l.startsWith('es')) return 'es';
   return 'en';
 })();
@@ -26,6 +27,7 @@ const UI = {
     ar: 'اختبار الشخصية',
     ru: 'Тест личности',
     es: 'Prueba de personalidad',
+    it: 'Test di personalità',
   },
   subtitle: {
     zh: '12 道题 · 约 2 分钟 · 本地计算，无需登录',
@@ -38,6 +40,7 @@ const UI = {
     ar: '12 سؤالًا · حوالي دقيقتين · يعمل محليًا، لا حاجة لتسجيل الدخول',
     ru: '12 вопросов · около 2 минут · локальный расчёт, без входа',
     es: '12 preguntas · aproximadamente 2 minutos · se ejecuta localmente, sin iniciar sesión',
+    it: '12 domande · circa 2 minuti · esecuzione locale, nessun accesso richiesto',
   },
   submit: {
     zh: '提交并查看结果',
@@ -50,6 +53,7 @@ const UI = {
     ar: 'إرسال وعرض النتيجة',
     ru: 'Отправить и посмотреть результат',
     es: 'Enviar y ver resultado',
+    it: 'Invia e visualizza il risultato',
   },
   reset: {
     zh: '清空重做',
@@ -62,6 +66,7 @@ const UI = {
     ar: 'إعادة تعيين',
     ru: 'Сбросить',
     es: 'Reiniciar',
+    it: 'Reimposta',
   },
   privacy: {
     zh: '隐私政策',
@@ -74,6 +79,7 @@ const UI = {
     ar: 'سياسة الخصوصية',
     ru: 'Политика конфиденциальности',
     es: 'Política de privacidad',
+    it: 'Informativa sulla privacy',
   },
   terms: {
     zh: '服务条款',
@@ -86,6 +92,7 @@ const UI = {
     ar: 'شروط الخدمة',
     ru: 'Условия использования',
     es: 'Términos del servicio',
+    it: 'Termini di servizio',
   },
   disclaimer: {
     zh: '* 免责声明：本测试仅供娱乐与自我反思，不构成临床或诊断建议。',
@@ -98,6 +105,7 @@ const UI = {
     ar: '* إخلاء المسؤولية: هذا الاختبار للترفيه والتأمل الذاتي فقط ولا يُعد نصيحة طبية أو تشخيصية.',
     ru: '* Отказ от ответственности: этот тест предназначен только для развлечения и самоанализа и не является клинической или диагностической рекомендацией.',
     es: '* Aviso: esta prueba es solo para entretenimiento y auto-reflexión y no constituye consejo clínico ni diagnóstico.',
+    it: '* Dichiarazione: questo test è solo per intrattenimento e auto-riflessione e non costituisce un consiglio clinico o diagnostico.',
   },
   legend: {
     zh: n => `第 ${n} 题`,
@@ -110,6 +118,7 @@ const UI = {
     ar: n => `السؤال ${n}`,
     ru: n => `Вопрос ${n}`,
     es: n => `Pregunta ${n}`,
+    it: n => `Domanda ${n}`,
   },
   unfinished: {
     zh: n => `还有题目未作答（第 ${n} 题）`,
@@ -122,6 +131,7 @@ const UI = {
     ar: n => `السؤال ${n} لم يتم الإجابة عليه.`,
     ru: n => `Вопрос ${n} не отвечен.`,
     es: n => `La pregunta ${n} no está respondida.`,
+    it: n => `La domanda ${n} non è stata completata.`,
   },
   copyright: {
     zh: '© 2025 Psychotest',
@@ -134,6 +144,7 @@ const UI = {
     ar: '© 2025 Psychotest',
     ru: '© 2025 Psychotest',
     es: '© 2025 Psychotest',
+    it: '© 2025 Psychotest',
   },
 };
 
@@ -153,6 +164,7 @@ const QUESTIONS = [
       ar: 'في المواقف الاجتماعية الجديدة، يمكنك كسر الجليد بسرعة وبناء علاقات مع الآخرين.',
       ru: 'В новых социальных ситуациях вы быстро находите общий язык и устанавливаете связи с другими.',
       es: 'En nuevos entornos sociales, puedes romper el hielo rápidamente y conectar con los demás.',
+      it: 'In nuovi contesti sociali riesci a rompere il ghiaccio rapidamente e a connetterti con gli altri.',
     },
     dim: 'connector',
   },
@@ -168,6 +180,7 @@ const QUESTIONS = [
       ar: 'عندما تواجه مشكلة، تفضّل مناقشتها مع الآخرين بدلاً من التفكير وحدك.',
       ru: 'Столкнувшись с проблемой, вы предпочитаете обсудить её с другими, а не думать в одиночку.',
       es: 'Cuando enfrentas problemas, prefieres discutirlos con otros en lugar de pensar solo.',
+      it: 'Quando affronti un problema preferisci discuterne con gli altri piuttosto che riflettere da solo.',
     },
     dim: 'connector',
   },
@@ -183,6 +196,7 @@ const QUESTIONS = [
       ar: 'تحب أن تبدأ المواضيع في الدردشات الجماعية أو الاجتماعات.',
       ru: 'В групповых чатах или на встречах вам нравится начинать обсуждения.',
       es: 'Te gusta iniciar temas en los chats grupales o reuniones.',
+      it: 'Ti piace avviare argomenti nelle chat di gruppo o nelle riunioni.',
     },
     dim: 'connector',
   },
@@ -200,6 +214,7 @@ const QUESTIONS = [
       ar: 'تستمتع بتجربة أدوات أو طرق أو مسارات جديدة تمامًا.',
       ru: 'Вы с удовольствием пробуете совершенно новые инструменты, методы или пути.',
       es: 'Disfrutas probar herramientas, métodos o caminos completamente nuevos.',
+      it: 'Ti piace provare strumenti, metodi o percorsi completamente nuovi.',
     },
     dim: 'explorer',
   },
@@ -215,6 +230,7 @@ const QUESTIONS = [
       ar: 'عندما تواجه المجهول أو التغيير، تشعر بالحماس أكثر من القلق.',
       ru: 'Столкнувшись с неизвестностью или переменами, вы больше возбуждены, чем обеспокоены.',
       es: 'Cuando te enfrentas a lo desconocido o a cambios, sientes más emoción que ansiedad.',
+      it: "Di fronte all'ignoto o ai cambiamenti ti senti più eccitato che ansioso.",
     },
     dim: 'explorer',
   },
@@ -230,6 +246,7 @@ const QUESTIONS = [
       ar: 'تستمتع بالخطط المفاجئة، مثل الرحلات العفوية.',
       ru: 'Вам нравятся спонтанные планы, например, внезапные поездки.',
       es: 'Disfrutas de planes espontáneos, como viajes improvisados.',
+      it: 'Ti divertono i piani improvvisati, come i viaggi spontanei.',
     },
     dim: 'explorer',
   },
@@ -247,6 +264,7 @@ const QUESTIONS = [
       ar: 'تقسّم المهام وتجدولها خطوة بخطوة.',
       ru: 'Вы разбиваете задачи на этапы и планируете их шаг за шагом.',
       es: 'Desglosas las tareas y las programas paso a paso.',
+      it: 'Scomponi le cose da fare e le pianifichi passo dopo passo.',
     },
     dim: 'organizer',
   },
@@ -262,6 +280,7 @@ const QUESTIONS = [
       ar: 'تميل إلى تنفيذ الخطط خطوة بخطوة، متجنبًا الطرق المختصرة.',
       ru: 'Вы склонны следовать плану шаг за шагом, избегая коротких путей.',
       es: 'Tiendes a seguir los planes paso a paso, evitando atajos.',
+      it: 'Tendi a seguire i piani passo dopo passo, evitando scorciatoie.',
     },
     dim: 'organizer',
   },
@@ -277,6 +296,7 @@ const QUESTIONS = [
       ar: 'التغييرات المفاجئة في الخطة تجعلك غير مرتاح أو حتى منزعجًا.',
       ru: 'Внезапные изменения планов вызывают у вас дискомфорт или даже раздражение.',
       es: 'Los cambios de planes de última hora te incomodan o incluso te molestan.',
+      it: "Le modifiche dell'ultimo minuto ai piani ti mettono a disagio o ti infastidiscono.",
     },
     dim: 'organizer',
   },
@@ -294,6 +314,7 @@ const QUESTIONS = [
       ar: 'قبل اتخاذ قرارات مهمة، تجمع أكبر قدر ممكن من الحقائق والبيانات.',
       ru: 'Прежде чем принять важное решение, вы собираете как можно больше фактов и данных.',
       es: 'Antes de tomar decisiones importantes, recopilas tantos hechos y datos como sea posible.',
+      it: 'Prima di prendere decisioni importanti raccogli quante più informazioni e dati possibile.',
     },
     dim: 'analyst',
   },
@@ -309,6 +330,7 @@ const QUESTIONS = [
       ar: 'غالبًا ما تستخدم الرسوم البيانية أو البيانات لشرح أفكارك.',
       ru: 'Вы часто используете графики или данные, чтобы объяснить свои идеи.',
       es: 'A menudo usas gráficos o datos para explicar tus ideas.',
+      it: 'Usi spesso grafici o dati per spiegare le tue idee.',
     },
     dim: 'analyst',
   },
@@ -324,16 +346,17 @@ const QUESTIONS = [
       ar: 'تبقى متشككًا في الاستنتاجات غير المثبتة وتبحث عن الأدلة.',
       ru: 'Вы скептически относитесь к непроверенным выводам и ищете доказательства.',
       es: 'Te mantienes escéptico ante conclusiones no verificadas y buscas evidencia.',
+      it: 'Rimani scettico di fronte a conclusioni non verificate e cerchi prove.',
     },
     dim: 'analyst',
   },
 ];
 
 const LIKERT = [
-  { value: 1, label: { zh: '非常不同意', 'zh-Hant': '非常不同意', en: 'Strongly disagree', ja: 'まったくそう思わない', ko: '전혀 동의하지 않음', fr: 'Tout à fait en désaccord', de: 'Stimme überhaupt nicht zu', ar: 'أعارض بشدة', ru: 'Совершенно не согласен', es: 'Totalmente en desacuerdo' } },
-  { value: 2, label: { zh: '不同意', 'zh-Hant': '不同意', en: 'Disagree', ja: 'そう思わない', ko: '동의하지 않음', fr: 'Pas d’accord', de: 'Stimme nicht zu', ar: 'أعارض', ru: 'Не согласен', es: 'En desacuerdo' } },
-  { value: 3, label: { zh: '一般', 'zh-Hant': '一般', en: 'Neutral', ja: 'どちらでもない', ko: '보통', fr: 'Neutre', de: 'Neutral', ar: 'محايد', ru: 'Нейтрально', es: 'Neutral' } },
-  { value: 4, label: { zh: '同意', 'zh-Hant': '同意', en: 'Agree', ja: 'そう思う', ko: '동의함', fr: 'D’accord', de: 'Stimme zu', ar: 'أوافق', ru: 'Согласен', es: 'De acuerdo' } },
-  { value: 5, label: { zh: '非常同意', 'zh-Hant': '非常同意', en: 'Strongly agree', ja: 'とてもそう思う', ko: '매우 동의함', fr: 'Tout à fait d’accord', de: 'Stimme voll zu', ar: 'أوافق بشدة', ru: 'Полностью согласен', es: 'Totalmente de acuerdo' } },
+  { value: 1, label: { zh: '非常不同意', 'zh-Hant': '非常不同意', en: 'Strongly disagree', ja: 'まったくそう思わない', ko: '전혀 동의하지 않음', fr: 'Tout à fait en désaccord', de: 'Stimme überhaupt nicht zu', ar: 'أعارض بشدة', ru: 'Совершенно не согласен', es: 'Totalmente en desacuerdo', it: 'Fortemente in disaccordo' } },
+  { value: 2, label: { zh: '不同意', 'zh-Hant': '不同意', en: 'Disagree', ja: 'そう思わない', ko: '동의하지 않음', fr: 'Pas d’accord', de: 'Stimme nicht zu', ar: 'أعارض', ru: 'Не согласен', es: 'En desacuerdo', it: 'In disaccordo' } },
+  { value: 3, label: { zh: '一般', 'zh-Hant': '一般', en: 'Neutral', ja: 'どちらでもない', ko: '보통', fr: 'Neutre', de: 'Neutral', ar: 'محايد', ru: 'Нейтрально', es: 'Neutral', it: 'Neutro' } },
+  { value: 4, label: { zh: '同意', 'zh-Hant': '同意', en: 'Agree', ja: 'そう思う', ko: '동의함', fr: 'D’accord', de: 'Stimme zu', ar: 'أوافق', ru: 'Согласен', es: 'De acuerdo', it: 'D’accordo' } },
+  { value: 5, label: { zh: '非常同意', 'zh-Hant': '非常同意', en: 'Strongly agree', ja: 'とてもそう思う', ko: '매우 동의함', fr: 'Tout à fait d’accord', de: 'Stimme voll zu', ar: 'أوافق بشدة', ru: 'Полностью согласен', es: 'Totalmente de acuerdo', it: 'Fortemente d’accordo' } },
 ];
 


### PR DESCRIPTION
## Summary
- detect Italian locale and provide full UI translations for quiz
- translate result pages and legal documents into Italian

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_6899ea88f040833389bb233f93727b9d