### PR TITLE
Fix dark mode submit button text visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -188,7 +188,7 @@ legend{
 
 .btn:not(.ghost){
   background: var(--primary);
-  color: #fff;
+  color: var(--bg);
 }
 .btn.ghost{
   background: transparent;


### PR DESCRIPTION
## Summary
- use background color variable for non-ghost buttons to ensure readable text in dark mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a334a32b88333970495a2db7648c9