### PR TITLE
Track submit button conversion

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,24 @@
     gtag('js', new Date());
     gtag('config', 'G-9PTHZ0E7NE');
   </script>
+  <!-- Google tag (gtag.js) event - delayed navigation helper -->
+  <script>
+    // Helper function to delay opening a URL until a gtag event is sent.
+    // Call it in response to an action that should navigate to a URL.
+    function gtagSendEvent(url) {
+      var callback = function () {
+        if (typeof url === 'string') {
+          window.location = url;
+        }
+      };
+      gtag('event', 'ads_conversion_submit_lead_form', {
+        'event_callback': callback,
+        'event_timeout': 2000,
+        // <event_parameters>
+      });
+      return false;
+    }
+  </script>
 </head>
 <body>
   <header class="container">

--- a/script.js
+++ b/script.js
@@ -87,7 +87,8 @@ function computeAndRedirect(e) {
 
   // Redirect to result page with query string containing raw scores
   const qs = new URLSearchParams(scores).toString();
-  location.href = `results/${winner}.html?${qs}`;
+  const url = `results/${winner}.html?${qs}`;
+  gtagSendEvent(url);
 }
 
 function resetForm() {


### PR DESCRIPTION
## Summary
- add Google Ads conversion helper for delayed navigation
- trigger conversion event before redirecting to results

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689aba5962e883338a054ba8d730c40c