### PR TITLE
Remove ads from legal pages

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,6 @@
   <meta property="og:type" content="website" />
   <meta property="og:locale" content="zh_CN" />
   <link rel="stylesheet" href="style.css" />
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4237167791029601" crossorigin="anonymous"></script>
-  <meta name="google-adsense-account" content="ca-pub-4237167791029601">
 </head>
 <body data-page="privacy">
   <header class="container">

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,6 @@
   <meta property="og:type" content="website" />
   <meta property="og:locale" content="zh_CN" />
   <link rel="stylesheet" href="style.css" />
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4237167791029601" crossorigin="anonymous"></script>
-  <meta name="google-adsense-account" content="ca-pub-4237167791029601">
 </head>
 <body data-page="terms">
   <header class="container">


### PR DESCRIPTION
## Summary
- remove AdSense script and meta from privacy policy
- remove AdSense script and meta from terms of service

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689af8e380c48333b395c08a4a50e264