### PR TITLE
Add Turkish and Hindi translations

### DIFF
--- a/legal.js
+++ b/legal.js
@@ -12,6 +12,8 @@ const LANG = (() => {
   if (l.startsWith('ru')) return 'ru';
   if (l.startsWith('it')) return 'it';
   if (l.startsWith('es')) return 'es';
+  if (l.startsWith('tr')) return 'tr';
+  if (l.startsWith('hi')) return 'hi';
   return 'en';
 })();
 
@@ -29,6 +31,8 @@ const LEGAL = {
       ru: 'Политика конфиденциальности',
       es: 'Política de privacidad',
       it: 'Informativa sulla privacy',
+      tr: 'Gizlilik Politikası',
+      hi: 'गोपनीयता नीति',
     },
     terms: {
       zh: '服务条款',
@@ -42,6 +46,8 @@ const LEGAL = {
       ru: 'Условия использования',
       es: 'Términos del servicio',
       it: 'Termini di servizio',
+      tr: 'Hizmet Şartları',
+      hi: 'सेवा की शर्तें',
     },
   },
   copyright: {
@@ -56,6 +62,8 @@ const LEGAL = {
     ru: '© 2025 Psychotest',
     es: '© 2025 Psychotest',
     it: '© 2025 Psychotest',
+    tr: '© 2025 Psychotest',
+    hi: '© 2025 Psychotest',
   },
   privacy: {
     title: {
@@ -70,6 +78,8 @@ const LEGAL = {
       ru: 'Политика конфиденциальности',
       es: 'Política de privacidad',
       it: 'Informativa sulla privacy',
+      tr: 'Gizlilik Politikası',
+      hi: 'गोपनीयता नीति',
     },
     content: {
       zh: '<p>我们尊重您的隐私。本网站不收集可识别个人身份的信息。广告和分析可能会使用 Cookie。</p><p>使用本网站即表示您同意谷歌及其他第三方按照其政策处理数据。</p>',
@@ -83,6 +93,8 @@ const LEGAL = {
       ru: '<p>Мы уважаем вашу конфиденциальность. Этот сайт не собирает персональные данные. Реклама и аналитика могут использовать cookies.</p><p>Используя сайт, вы соглашаетесь с правилами обработки данных Google и других сторон.</p>',
       es: '<p>Respetamos tu privacidad. Este sitio no recopila información personal identificable. Los anuncios y la analítica pueden usar cookies.</p><p>Al usar este sitio, aceptas las prácticas de datos de Google y otros terceros.</p>',
       it: '<p>Rispettiamo la tua privacy. Questo sito non raccoglie informazioni personali identificabili. Gli annunci e le analisi possono utilizzare cookie.</p><p>Utilizzando questo sito, accetti le pratiche sui dati di Google e di altre terze parti.</p>',
+      tr: '<p>Gizliliğinize saygı duyuyoruz. Bu site kişisel olarak tanımlanabilir bilgi toplamaz. Reklamlar ve analizler çerez kullanabilir.</p><p>Bu siteyi kullanarak Google ve diğer üçüncü tarafların veri uygulamalarını kabul etmiş olursunuz.</p>',
+      hi: '<p>हम आपकी गोपनीयता का सम्मान करते हैं। यह साइट व्यक्तिगत रूप से पहचान योग्य जानकारी एकत्र नहीं करती। विज्ञापन और विश्लेषण के लिए कुकीज़ का उपयोग किया जा सकता है।</p><p>इस साइट का उपयोग करने पर, आप Google और अन्य तृतीय पक्षों की डेटा नीतियों से सहमत होते हैं।</p>',
     },
   },
   terms: {
@@ -98,6 +110,8 @@ const LEGAL = {
       ru: 'Условия использования',
       es: 'Términos del servicio',
       it: 'Termini di servizio',
+      tr: 'Hizmet Şartları',
+      hi: 'सेवा की शर्तें',
     },
     content: {
       zh: '<p>使用本网站即表示您同意这些条款。本测试仅供娱乐，不构成专业建议。</p><p>我们不对因使用本网站而产生的任何损失负责。</p>',
@@ -111,6 +125,8 @@ const LEGAL = {
       ru: '<p>Используя сайт, вы соглашаетесь с этими условиями. Тест предназначен только для развлечения и не является профессиональным советом.</p><p>Мы не несем ответственности за какой-либо ущерб, возникший из-за использования сайта.</p>',
       es: '<p>Al usar este sitio, aceptas estos términos. La prueba es solo para entretenimiento y no constituye asesoramiento profesional.</p><p>No somos responsables de los daños derivados del uso de este sitio.</p>',
       it: '<p>Utilizzando questo sito accetti questi termini. Il test è solo a scopo di intrattenimento e non costituisce consulenza professionale.</p><p>Non siamo responsabili per eventuali danni derivanti dall\'uso di questo sito.</p>',
+      tr: '<p>Bu siteyi kullanarak bu şartları kabul etmiş olursunuz. Test yalnızca eğlence amaçlıdır ve profesyonel tavsiye değildir.</p><p>Bu siteyi kullanmaktan doğabilecek zararlardan sorumlu değiliz.</p>',
+      hi: '<p>इस साइट का उपयोग करके आप इन शर्तों से सहमत होते हैं। यह परीक्षण केवल मनोरंजन के लिए है और कोई पेशेवर सलाह नहीं है।</p><p>इस साइट के उपयोग से होने वाले किसी भी नुकसान के लिए हम जिम्मेदार नहीं हैं।</p>',
     },
   },
 };

--- a/results.js
+++ b/results.js
@@ -12,6 +12,8 @@ function detectLang() {
   if (l.startsWith('ru')) return 'ru';
   if (l.startsWith('it')) return 'it';
   if (l.startsWith('es')) return 'es';
+  if (l.startsWith('tr')) return 'tr';
+  if (l.startsWith('hi')) return 'hi';
   return 'en';
 }
 
@@ -196,6 +198,38 @@ const RES_UI = {
     colon: ': ',
     totalLabel: 'Totale: ',
   },
+  tr: {
+    header: 'Sonucun',
+    strengthsTitle: 'Güçlü Yönlerin',
+    tipsTitle: 'Sana Tavsiyeler',
+    scoresTitle: 'Bu Testteki Boyut Puanları',
+    loading: 'Yükleniyor...',
+    again: 'Tekrar Dene',
+    copy: 'Sonuç Bağlantısını Kopyala',
+    footer: '© 2025 Psychotest · <a href="../privacy.html">Gizlilik Politikası</a>｜<a href="../terms.html">Hizmet Şartları</a> · Bu test yalnızca eğlence ve öz değerlendirme içindir.',
+    copySuccess: 'Bağlantı kopyalandı.',
+    copyFail: 'Kopyalama başarısız, lütfen bağlantıyı elle kopyalayın',
+    labels: { connector: 'Bağlayıcı', explorer: 'Kaşif', organizer: 'Organizatör', analyst: 'Analist' },
+    sep: ' | ',
+    colon: ': ',
+    totalLabel: 'Toplam: ',
+  },
+  hi: {
+    header: 'आपका परिणाम',
+    strengthsTitle: 'आपकी ताकतें',
+    tipsTitle: 'आपके लिए सुझाव',
+    scoresTitle: 'इस परीक्षण के आयामों के स्कोर',
+    loading: 'लोड हो रहा है...',
+    again: 'फिर से करें',
+    copy: 'परिणाम लिंक कॉपी करें',
+    footer: '© 2025 Psychotest · <a href="../privacy.html">गोपनीयता नीति</a>｜<a href="../terms.html">सेवा की शर्तें</a> · यह परीक्षण केवल मनोरंजन और आत्म-चिंतन के लिए है।',
+    copySuccess: 'लिंक कॉपी हो गया।',
+    copyFail: 'कॉपी विफल, कृपया लिंक मैन्युअली कॉपी करें',
+    labels: { connector: 'संबंधक', explorer: 'अन्वेषक', organizer: 'संगठक', analyst: 'विश्लेषक' },
+    sep: ' | ',
+    colon: ': ',
+    totalLabel: 'कुल: ',
+  },
 };
 
 const RES_CONTENT = {
@@ -212,6 +246,8 @@ const RES_CONTENT = {
       ru: 'Коммуникатор (социально ориентированный) | Результат теста',
       es: 'Conector (Impulsado por lo social) | Resultado del test',
       it: 'Connettore (orientato al sociale) | Risultato del test',
+      tr: 'Bağlayıcı (Sosyal Odaklı) | Test Sonucu',
+      hi: 'संबंधक (सामाजिक प्रेरित) | परीक्षण परिणाम',
     },
     resultType: {
       zh: '连接者（社交驱动）<span class="badge">非临床 · 娱乐向</span>',
@@ -225,6 +261,8 @@ const RES_CONTENT = {
       ru: 'Коммуникатор (социально ориентированный)<span class="badge">Неклинический · Для развлечения</span>',
       es: 'Conector (Impulsado por lo social)<span class="badge">No clínico · Con fines recreativos</span>',
       it: 'Connettore (orientato al sociale)<span class="badge">Non clinico · Per divertimento</span>',
+      tr: 'Bağlayıcı (Sosyal Odaklı)<span class="badge">Klinik dışı · Eğlence amaçlı</span>',
+      hi: 'संबंधक (सामाजिक प्रेरित)<span class="badge">गैर-चिकित्सीय · मनोरंजन हेतु</span>',
     },
     kv: {
       zh: '类型代号：<code>connector</code>',
@@ -238,6 +276,8 @@ const RES_CONTENT = {
       ru: 'Код типа: <code>connector</code>',
       es: 'Código de tipo: <code>connector</code>',
       it: 'Codice tipo: <code>connector</code>',
+      tr: 'Tür kodu: <code>connector</code>',
+      hi: 'प्रकार कोड: <code>connector</code>',
     },
     strengths: {
       zh: [
@@ -294,6 +334,16 @@ const RES_CONTENT = {
         'Abile nella comunicazione e collaborazione, costruisce rapidamente fiducia e intesa.',
         'Nel team potenzia gli altri facilitando il flusso di informazioni e il raggiungimento del consenso.',
         'Bravo a integrare risorse e a far avanzare progetti trasversali ai reparti.',
+      ],
+      tr: [
+        'İletişim ve işbirliğinde iyidir, hızlıca güven ve uyum kurar.',
+        'Takımda başkalarını güçlendirir, bilgi akışını ve uzlaşıyı kolaylaştırır.',
+        'Kaynakları entegre etmede ve departmanlar arası projeleri yürütmede ustadır.',
+      ],
+      hi: [
+        'संचार और सहयोग में माहिर, जल्दी ही भरोसा और तालमेल बना लेते हैं।',
+        'टीम में दूसरों को सशक्त करते हैं, सूचना प्रवाह और सहमति को सुगम बनाते हैं।',
+        'संसाधनों को एकीकृत करने और विभागों के बीच परियोजनाओं को आगे बढ़ाने में कुशल।',
       ],
     },
     tips: {
@@ -352,6 +402,16 @@ const RES_CONTENT = {
         'Impara a rifiutare cortesemente le richieste a bassa priorità per proteggere il tempo di lavoro profondo.',
         'Collabora con gli “Analisti” per supportare le idee con dati e aumentarne la forza persuasiva.',
       ],
+      tr: [
+        'Karmaşık görevler için kontrol listeleri ve tempo planları oluştur; “çok konuşup az yapmak”tan kaçın.',
+        'Derin çalışma zamanını korumak için düşük öncelikli istekleri nazikçe reddetmeyi öğren.',
+        'Fikirlerini verilerle desteklemek ve ikna gücünü artırmak için “Analistler”le işbirliği yap.',
+      ],
+      hi: [
+        'जटिल कार्यों के लिए चेकलिस्ट और तालिका बनाएं ताकि “ज्यादा बोलना, कम करना” से बच सकें।',
+        'गहरे काम के समय की रक्षा हेतु कम प्राथमिकता वाले अनुरोधों को विनम्रता से मना करना सीखें।',
+        'डेटा के साथ विचारों का समर्थन करने और प्रभावशीलता बढ़ाने के लिए “विश्लेषकों” के साथ साझेदारी करें।',
+      ],
     },
   },
 
@@ -368,6 +428,8 @@ const RES_CONTENT = {
       ru: 'Исследователь (любопытный новатор) | Результат теста',
       es: 'Explorador (Curioso e innovador) | Resultado del test',
       it: 'Esploratore (curioso e innovatore) | Risultato del test',
+      tr: 'Kaşif (Meraklı Yenilikçi) | Test Sonucu',
+      hi: 'अन्वेषक (जिज्ञासु नवाचारी) | परीक्षण परिणाम',
     },
     resultType: {
       zh: '探索者（好奇创新）<span class="badge">非临床 · 娱乐向</span>',
@@ -381,6 +443,8 @@ const RES_CONTENT = {
       ru: 'Исследователь (любопытный новатор)<span class="badge">Неклинический · Для развлечения</span>',
       es: 'Explorador (Curioso e innovador)<span class="badge">No clínico · Con fines recreativos</span>',
       it: 'Esploratore (curioso e innovatore)<span class="badge">Non clinico · Per divertimento</span>',
+      tr: 'Kaşif (Meraklı Yenilikçi)<span class="badge">Klinik dışı · Eğlence amaçlı</span>',
+      hi: 'अन्वेषक (जिज्ञासु नवाचारी)<span class="badge">गैर-चिकित्सीय · मनोरंजन हेतु</span>',
     },
     kv: {
       zh: '类型代号：<code>explorer</code>',
@@ -394,6 +458,8 @@ const RES_CONTENT = {
       ru: 'Код типа: <code>explorer</code>',
       es: 'Código de tipo: <code>explorer</code>',
       it: 'Codice tipo: <code>explorer</code>',
+      tr: 'Tür kodu: <code>explorer</code>',
+      hi: 'प्रकार कोड: <code>explorer</code>',
     },
     strengths: {
       zh: [
@@ -450,6 +516,16 @@ const RES_CONTENT = {
         'Sensibile alle novità e rapido nel provare e sbagliare per trovare punti di svolta.',
         'Creativo e bravo a porre domande da prospettive diverse.',
         'Si adatta velocemente ai cambiamenti e abbraccia l\'incertezza.',
+      ],
+      tr: [
+        'Yeniliklere duyarlıdır, hızlı deneme-yanılma ile atılım bulur.',
+        'Yaratıcıdır, farklı açılardan sorular sormakta iyidir.',
+        'Değişime hızla uyum sağlar ve belirsizliği kucaklar.',
+      ],
+      hi: [
+        'नई चीज़ों के प्रति संवेदनशील हैं और प्रयोग-त्रुटि से जल्दी समाधान खोज लेते हैं।',
+        'रचनात्मक हैं और विभिन्न दृष्टिकोणों से प्रश्न पूछने में सक्षम।',
+        'परिवर्तन के प्रति जल्दी अनुकूलन करते हैं और अनिश्चितता को स्वीकारते हैं।',
       ],
     },
     tips: {
@@ -508,6 +584,16 @@ const RES_CONTENT = {
         'Trasforma le ispirazioni in modelli o procedure operative standard riutilizzabili.',
         'Collabora con gli “Organizzatori” per trasformare le idee in piani attuabili.',
       ],
+      tr: [
+        'Her deney için hedef, zaman kutusu, metrikler ve çıkış kriterleri gibi sınırlar koy.',
+        'İlhamlarını yeniden kullanılabilir şablonlara veya SOP’lere dönüştür.',
+        'Fikirleri uygulanabilir planlara dönüştürmek için “Organizatörler”le işbirliği yap.',
+      ],
+      hi: [
+        'प्रत्येक प्रयोग के लिए लक्ष्य, समय सीमा, मापदंड और बाहर निकलने की शर्तें तय करें।',
+        'प्रेरणाओं को पुन: उपयोग योग्य टेम्पलेट या SOP में बदलें।',
+        'विचारों को क्रियाशील योजनाओं में बदलने के लिए “संगठकों” के साथ साझेदारी करें।',
+      ],
     },
   },
 
@@ -524,6 +610,8 @@ const RES_CONTENT = {
       ru: 'Организатор (упорядоченный исполнитель) | Результат теста',
       es: 'Organizador (Ejecución ordenada) | Resultado del test',
       it: 'Organizzatore (esecutore ordinato) | Risultato del test',
+      tr: 'Organizatör (Düzenli Uygulayıcı) | Test Sonucu',
+      hi: 'संगठक (सुव्यवस्थित कार्यकर्ता) | परीक्षण परिणाम',
     },
     resultType: {
       zh: '组织者（有序执行）<span class="badge">非临床 · 娱乐向</span>',
@@ -537,6 +625,8 @@ const RES_CONTENT = {
       ru: 'Организатор (упорядоченный исполнитель)<span class="badge">Неклинический · Для развлечения</span>',
       es: 'Organizador (Ejecución ordenada)<span class="badge">No clínico · Con fines recreativos</span>',
       it: 'Organizzatore (esecutore ordinato)<span class="badge">Non clinico · Per divertimento</span>',
+      tr: 'Organizatör (Düzenli Uygulayıcı)<span class="badge">Klinik dışı · Eğlence amaçlı</span>',
+      hi: 'संगठक (सुव्यवस्थित कार्यकर्ता)<span class="badge">गैर-चिकित्सीय · मनोरंजन हेतु</span>',
     },
     kv: {
       zh: '类型代号：<code>organizer</code>',
@@ -550,6 +640,8 @@ const RES_CONTENT = {
       ru: 'Код типа: <code>organizer</code>',
       es: 'Código de tipo: <code>organizer</code>',
       it: 'Codice tipo: <code>organizer</code>',
+      tr: 'Tür kodu: <code>organizer</code>',
+      hi: 'प्रकार कोड: <code>organizer</code>',
     },
     strengths: {
       zh: [
@@ -606,6 +698,16 @@ const RES_CONTENT = {
         'Abile nella scomposizione degli obiettivi, nella gestione del ritmo e nel monitoraggio dei progressi.',
         'Stabile e affidabile, capace di concretizzare progetti complessi.',
         'Attento alle norme e alla qualità, con grande cura per i dettagli.',
+      ],
+      tr: [
+        'Hedefleri parçalara ayırma, tempo yönetimi ve ilerleme takibinde ustadır.',
+        'Stabil ve güvenilirdir, karmaşık projeleri hayata geçirebilir.',
+        'Standartlara ve kaliteye odaklanır, ayrıntılara dikkat eder.',
+      ],
+      hi: [
+        'लक्ष्यों को भागों में बाँटना, गति प्रबंधन और प्रगति ट्रैक करने में माहिर।',
+        'स्थिर और भरोसेमंद, जटिल परियोजनाओं को पूरा करने में सक्षम।',
+        'मानकों और गुणवत्ता पर ध्यान, बारीकियों पर पकड़।',
       ],
     },
     tips: {
@@ -664,6 +766,16 @@ const RES_CONTENT = {
         'Rivedi regolarmente per assicurarti di concentrarti sul 20% con il maggiore impatto.',
         'Collabora con gli “Esploratori” per infondere innovazione nei processi.',
       ],
+      tr: [
+        'Mükemmelliği aşırı kovalamaktan kaçın; planlarda esnek tamponlar bırak.',
+        'Düzenli olarak gözden geçir; en etkili %20’ye odaklandığından emin ol.',
+        'Süreçlere yenilik katmak için “Kaşifler”le çalış.',
+      ],
+      hi: [
+        'अत्यधिक पूर्णता की तलाश से बचें; योजनाओं में लचीला बफर छोड़ें।',
+        'नियमित रूप से समीक्षा करें ताकि सबसे प्रभावशाली 20% पर ध्यान केंद्रित रहे।',
+        'प्रक्रियाओं में नवाचार लाने के लिए “अन्वेषकों” के साथ काम करें।',
+      ],
     },
   },
 
@@ -680,6 +792,8 @@ const RES_CONTENT = {
       ru: 'Аналитик (ориентированный на данные) | Результат теста',
       es: 'Analista (Orientado a los datos) | Resultado del test',
       it: 'Analista (guidato dai dati) | Risultato del test',
+      tr: 'Analist (Veri Odaklı) | Test Sonucu',
+      hi: 'विश्लेषक (डेटा संचालित) | परीक्षण परिणाम',
     },
     resultType: {
       zh: '分析者（数据理性）<span class="badge">非临床 · 娱乐向</span>',
@@ -693,6 +807,8 @@ const RES_CONTENT = {
       ru: 'Аналитик (ориентированный на данные)<span class="badge">Неклинический · Для развлечения</span>',
       es: 'Analista (Orientado a los datos)<span class="badge">No clínico · Con fines recreativos</span>',
       it: 'Analista (guidato dai dati)<span class="badge">Non clinico · Per divertimento</span>',
+      tr: 'Analist (Veri Odaklı)<span class="badge">Klinik dışı · Eğlence amaçlı</span>',
+      hi: 'विश्लेषक (डेटा संचालित)<span class="badge">गैर-चिकित्सीय · मनोरंजन हेतु</span>',
     },
     kv: {
       zh: '类型代号：<code>analyst</code>',
@@ -706,6 +822,8 @@ const RES_CONTENT = {
       ru: 'Код типа: <code>analyst</code>',
       es: 'Código de tipo: <code>analyst</code>',
       it: 'Codice tipo: <code>analyst</code>',
+      tr: 'Tür kodu: <code>analyst</code>',
+      hi: 'प्रकार कोड: <code>analyst</code>',
     },
     strengths: {
       zh: [
@@ -763,6 +881,16 @@ const RES_CONTENT = {
         "Abile nell'usare modelli e dati per rivelare i problemi fondamentali.",
         'Capace di costruire sistemi di valutazione e di ottimizzarli continuamente.',
       ],
+      tr: [
+        'Kanıta odaklıdır, titiz mantık yürütür ve sağlam hüküm verir.',
+        'Modelleri ve verileri kullanarak temel sorunları ortaya çıkarmada ustadır.',
+        'Değerlendirme sistemleri kurmada ve bunları sürekli geliştirmede iyidir.',
+      ],
+      hi: [
+        'साक्ष्य-उन्मुख, तर्क में कठोर और निर्णय में दृढ़।',
+        'मॉडल और डेटा का उपयोग कर मूल समस्याओं को उजागर करने में कुशल।',
+        'मूल्यांकन प्रणालियाँ बनाने और उन्हें निरंतर बेहतर करने में सक्षम।',
+      ],
     },
     tips: {
       zh: [
@@ -819,6 +947,16 @@ const RES_CONTENT = {
         'Attenzione alla “paralisi da analisi”; stabilisci punti decisionali chiari.',
         'Cocrea con i partner di business per fare in modo che i report portino ad azioni.',
         'Collabora con i “Connettori” per tradurre gli insight in un linguaggio comprensibile e attuabile.',
+      ],
+      tr: [
+        '“Analiz felci”ne dikkat et; araştırmalara net karar noktaları koy.',
+        'Raporların eyleme dönüşmesi için iş ortaklarıyla birlikte çalış.',
+        'İçgörüleri anlaşılır ve uygulanabilir dile çevirmek için “Bağlayıcılar”la işbirliği yap.',
+      ],
+      hi: [
+        '“विश्लेषण पक्षाघात” से सावधान रहें; शोध के लिए स्पष्ट निर्णय बिंदु निर्धारित करें।',
+        'रिपोर्टों को कार्रवाई में बदलने के लिए व्यापार साझेदारों के साथ सह-निर्माण करें।',
+        'अंतर्दृष्टियों को सरल और क्रियान्वयन योग्य भाषा में बदलने के लिए “संबंधकों” के साथ सहयोग करें।',
       ],
     },
   },

--- a/translations.js
+++ b/translations.js
@@ -12,6 +12,8 @@ const LANG = (() => {
   if (l.startsWith('ru')) return 'ru';
   if (l.startsWith('it')) return 'it';
   if (l.startsWith('es')) return 'es';
+  if (l.startsWith('tr')) return 'tr';
+  if (l.startsWith('hi')) return 'hi';
   return 'en';
 })();
 
@@ -28,6 +30,8 @@ const UI = {
     ru: 'Тест личности',
     es: 'Prueba de personalidad',
     it: 'Test di personalità',
+    tr: 'Kişilik Testi',
+    hi: 'व्यक्तित्व परीक्षण',
   },
   subtitle: {
     zh: '12 道题 · 约 2 分钟 · 本地计算，无需登录',
@@ -41,6 +45,8 @@ const UI = {
     ru: '12 вопросов · около 2 минут · локальный расчёт, без входа',
     es: '12 preguntas · aproximadamente 2 minutos · se ejecuta localmente, sin iniciar sesión',
     it: '12 domande · circa 2 minuti · esecuzione locale, nessun accesso richiesto',
+    tr: '12 soru · yaklaşık 2 dakika · yerel olarak çalışır, giriş gerekmez',
+    hi: '12 प्रश्न · लगभग 2 मिनट · स्थानीय रूप से चलता है, लॉगइन की आवश्यकता नहीं',
   },
   submit: {
     zh: '提交并查看结果',
@@ -54,6 +60,8 @@ const UI = {
     ru: 'Отправить и посмотреть результат',
     es: 'Enviar y ver resultado',
     it: 'Invia e visualizza il risultato',
+    tr: 'Gönder ve Sonucu Gör',
+    hi: 'जमा करें और परिणाम देखें',
   },
   reset: {
     zh: '清空重做',
@@ -67,6 +75,8 @@ const UI = {
     ru: 'Сбросить',
     es: 'Reiniciar',
     it: 'Reimposta',
+    tr: 'Sıfırla',
+    hi: 'रीसेट',
   },
   privacy: {
     zh: '隐私政策',
@@ -80,6 +90,8 @@ const UI = {
     ru: 'Политика конфиденциальности',
     es: 'Política de privacidad',
     it: 'Informativa sulla privacy',
+    tr: 'Gizlilik Politikası',
+    hi: 'गोपनीयता नीति',
   },
   terms: {
     zh: '服务条款',
@@ -93,6 +105,8 @@ const UI = {
     ru: 'Условия использования',
     es: 'Términos del servicio',
     it: 'Termini di servizio',
+    tr: 'Hizmet Şartları',
+    hi: 'सेवा की शर्तें',
   },
   disclaimer: {
     zh: '* 免责声明：本测试仅供娱乐与自我反思，不构成临床或诊断建议。',
@@ -106,6 +120,8 @@ const UI = {
     ru: '* Отказ от ответственности: этот тест предназначен только для развлечения и самоанализа и не является клинической или диагностической рекомендацией.',
     es: '* Aviso: esta prueba es solo para entretenimiento y auto-reflexión y no constituye consejo clínico ni diagnóstico.',
     it: '* Dichiarazione: questo test è solo per intrattenimento e auto-riflessione e non costituisce un consiglio clinico o diagnostico.',
+    tr: '* Feragatname: Bu test yalnızca eğlence ve öz değerlendirme içindir, klinik veya teşhis niteliğinde değildir.',
+    hi: '* अस्वीकरण: यह परीक्षण केवल मनोरंजन और आत्म-चिंतन के लिए है, यह किसी प्रकार की चिकित्सीय या निदान सलाह नहीं है।',
   },
   legend: {
     zh: n => `第 ${n} 题`,
@@ -119,6 +135,8 @@ const UI = {
     ru: n => `Вопрос ${n}`,
     es: n => `Pregunta ${n}`,
     it: n => `Domanda ${n}`,
+    tr: n => `Soru ${n}`,
+    hi: n => `प्रश्न ${n}`,
   },
   unfinished: {
     zh: n => `还有题目未作答（第 ${n} 题）`,
@@ -132,6 +150,8 @@ const UI = {
     ru: n => `Вопрос ${n} не отвечен.`,
     es: n => `La pregunta ${n} no está respondida.`,
     it: n => `La domanda ${n} non è stata completata.`,
+    tr: n => `Soru ${n} cevaplanmadı.`,
+    hi: n => `प्रश्न ${n} का उत्तर नहीं दिया गया है。`,
   },
   copyright: {
     zh: '© 2025 Psychotest',
@@ -145,6 +165,8 @@ const UI = {
     ru: '© 2025 Psychotest',
     es: '© 2025 Psychotest',
     it: '© 2025 Psychotest',
+    tr: '© 2025 Psychotest',
+    hi: '© 2025 Psychotest',
   },
 };
 
@@ -165,6 +187,8 @@ const QUESTIONS = [
       ru: 'В новых социальных ситуациях вы быстро находите общий язык и устанавливаете связи с другими.',
       es: 'En nuevos entornos sociales, puedes romper el hielo rápidamente y conectar con los demás.',
       it: 'In nuovi contesti sociali riesci a rompere il ghiaccio rapidamente e a connetterti con gli altri.',
+      tr: 'Yeni sosyal ortamlarda hızla buzları kırar ve başkalarıyla bağlantı kurarsın.',
+      hi: 'नए सामाजिक माहौल में आप जल्दी से बर्फ़ तोड़कर दूसरों से जुड़ जाते हैं।',
     },
     dim: 'connector',
   },
@@ -181,6 +205,8 @@ const QUESTIONS = [
       ru: 'Столкнувшись с проблемой, вы предпочитаете обсудить её с другими, а не думать в одиночку.',
       es: 'Cuando enfrentas problemas, prefieres discutirlos con otros en lugar de pensar solo.',
       it: 'Quando affronti un problema preferisci discuterne con gli altri piuttosto che riflettere da solo.',
+      tr: 'Sorunlarla karşılaştığında yalnız düşünmek yerine başkalarıyla tartışmayı tercih edersin.',
+      hi: 'समस्याओं का सामना करते समय आप अकेले सोचने की बजाय दूसरों के साथ चर्चा करना पसंद करते हैं।',
     },
     dim: 'connector',
   },
@@ -197,6 +223,8 @@ const QUESTIONS = [
       ru: 'В групповых чатах или на встречах вам нравится начинать обсуждения.',
       es: 'Te gusta iniciar temas en los chats grupales o reuniones.',
       it: 'Ti piace avviare argomenti nelle chat di gruppo o nelle riunioni.',
+      tr: 'Grup sohbetlerinde veya toplantılarda konuları başlatmayı seversin.',
+      hi: 'आप समूह चैट या बैठकों में विषय शुरू करना पसंद करते हैं।',
     },
     dim: 'connector',
   },
@@ -215,6 +243,8 @@ const QUESTIONS = [
       ru: 'Вы с удовольствием пробуете совершенно новые инструменты, методы или пути.',
       es: 'Disfrutas probar herramientas, métodos o caminos completamente nuevos.',
       it: 'Ti piace provare strumenti, metodi o percorsi completamente nuovi.',
+      tr: 'Tamamen yeni araçları, yöntemleri veya yolları denemekten hoşlanırsın.',
+      hi: 'आप पूरी तरह नए उपकरणों, तरीकों या रास्तों को आज़माने का आनंद लेते हैं।',
     },
     dim: 'explorer',
   },
@@ -231,6 +261,8 @@ const QUESTIONS = [
       ru: 'Столкнувшись с неизвестностью или переменами, вы больше возбуждены, чем обеспокоены.',
       es: 'Cuando te enfrentas a lo desconocido o a cambios, sientes más emoción que ansiedad.',
       it: "Di fronte all'ignoto o ai cambiamenti ti senti più eccitato che ansioso.",
+      tr: 'Bilinmeyenle veya değişimle karşılaştığında kaygıdan çok heyecan hissedersin.',
+      hi: 'अज्ञात या परिवर्तन का सामना करते समय आप चिंतित होने की बजाय अधिक उत्साहित महसूस करते हैं।',
     },
     dim: 'explorer',
   },
@@ -247,6 +279,8 @@ const QUESTIONS = [
       ru: 'Вам нравятся спонтанные планы, например, внезапные поездки.',
       es: 'Disfrutas de planes espontáneos, como viajes improvisados.',
       it: 'Ti divertono i piani improvvisati, come i viaggi spontanei.',
+      tr: 'Ani planları, örneğin spontane gezileri seviyorsun.',
+      hi: 'आप अचानक बनने वाले योजनाओं, जैसे तुरंत किए गए सफ़रों का आनंद लेते हैं।',
     },
     dim: 'explorer',
   },
@@ -265,6 +299,8 @@ const QUESTIONS = [
       ru: 'Вы разбиваете задачи на этапы и планируете их шаг за шагом.',
       es: 'Desglosas las tareas y las programas paso a paso.',
       it: 'Scomponi le cose da fare e le pianifichi passo dopo passo.',
+      tr: 'Yapılacakları parçalara ayırır ve adım adım takvime yerleştirirsin.',
+      hi: 'आप कार्यों को छोटे हिस्सों में बाँटकर उन्हें क्रमबद्ध तरीके से समय-सारणी में रखते हैं।',
     },
     dim: 'organizer',
   },
@@ -281,6 +317,8 @@ const QUESTIONS = [
       ru: 'Вы склонны следовать плану шаг за шагом, избегая коротких путей.',
       es: 'Tiendes a seguir los planes paso a paso, evitando atajos.',
       it: 'Tendi a seguire i piani passo dopo passo, evitando scorciatoie.',
+      tr: 'Kısa yolları kullanmak yerine planları adım adım izlemeyi tercih edersin.',
+      hi: 'आप योजनाओं को चरणबद्ध तरीके से अनुसरण करना पसंद करते हैं और शॉर्टकट से बचते हैं।',
     },
     dim: 'organizer',
   },
@@ -297,6 +335,8 @@ const QUESTIONS = [
       ru: 'Внезапные изменения планов вызывают у вас дискомфорт или даже раздражение.',
       es: 'Los cambios de planes de última hora te incomodan o incluso te molestan.',
       it: "Le modifiche dell'ultimo minuto ai piani ti mettono a disagio o ti infastidiscono.",
+      tr: 'Planların son anda değişmesi seni rahatsız eder, hatta kızdırabilir.',
+      hi: 'योजनाओं में आखिरी क्षण में परिवर्तन आपको असहज या यहाँ तक कि नाराज़ भी कर देता है।',
     },
     dim: 'organizer',
   },
@@ -315,6 +355,8 @@ const QUESTIONS = [
       ru: 'Прежде чем принять важное решение, вы собираете как можно больше фактов и данных.',
       es: 'Antes de tomar decisiones importantes, recopilas tantos hechos y datos como sea posible.',
       it: 'Prima di prendere decisioni importanti raccogli quante più informazioni e dati possibile.',
+      tr: 'Önemli kararlar almadan önce olabildiğince çok bilgi ve veri toplarsın.',
+      hi: 'महत्वपूर्ण निर्णय लेने से पहले आप यथासंभव अधिक तथ्य और डेटा एकत्र करते हैं।',
     },
     dim: 'analyst',
   },
@@ -331,6 +373,8 @@ const QUESTIONS = [
       ru: 'Вы часто используете графики или данные, чтобы объяснить свои идеи.',
       es: 'A menudo usas gráficos o datos para explicar tus ideas.',
       it: 'Usi spesso grafici o dati per spiegare le tue idee.',
+      tr: 'Düşüncelerini açıklamak için sık sık grafikler veya veriler kullanırsın.',
+      hi: 'आप अपने विचारों को समझाने के लिए अक्सर चार्ट या डेटा का उपयोग करते हैं।',
     },
     dim: 'analyst',
   },
@@ -347,16 +391,18 @@ const QUESTIONS = [
       ru: 'Вы скептически относитесь к непроверенным выводам и ищете доказательства.',
       es: 'Te mantienes escéptico ante conclusiones no verificadas y buscas evidencia.',
       it: 'Rimani scettico di fronte a conclusioni non verificate e cerchi prove.',
+      tr: 'Doğrulanmamış sonuçlara şüpheyle yaklaşır ve kanıt ararsın.',
+      hi: 'आप अप्रमाणित निष्कर्षों के प्रति संदेहपूर्ण रहते हैं और सबूत खोजते हैं।',
     },
     dim: 'analyst',
   },
 ];
 
 const LIKERT = [
-  { value: 1, label: { zh: '非常不同意', 'zh-Hant': '非常不同意', en: 'Strongly disagree', ja: 'まったくそう思わない', ko: '전혀 동의하지 않음', fr: 'Tout à fait en désaccord', de: 'Stimme überhaupt nicht zu', ar: 'أعارض بشدة', ru: 'Совершенно не согласен', es: 'Totalmente en desacuerdo', it: 'Fortemente in disaccordo' } },
-  { value: 2, label: { zh: '不同意', 'zh-Hant': '不同意', en: 'Disagree', ja: 'そう思わない', ko: '동의하지 않음', fr: 'Pas d’accord', de: 'Stimme nicht zu', ar: 'أعارض', ru: 'Не согласен', es: 'En desacuerdo', it: 'In disaccordo' } },
-  { value: 3, label: { zh: '一般', 'zh-Hant': '一般', en: 'Neutral', ja: 'どちらでもない', ko: '보통', fr: 'Neutre', de: 'Neutral', ar: 'محايد', ru: 'Нейтрально', es: 'Neutral', it: 'Neutro' } },
-  { value: 4, label: { zh: '同意', 'zh-Hant': '同意', en: 'Agree', ja: 'そう思う', ko: '동의함', fr: 'D’accord', de: 'Stimme zu', ar: 'أوافق', ru: 'Согласен', es: 'De acuerdo', it: 'D’accordo' } },
-  { value: 5, label: { zh: '非常同意', 'zh-Hant': '非常同意', en: 'Strongly agree', ja: 'とてもそう思う', ko: '매우 동의함', fr: 'Tout à fait d’accord', de: 'Stimme voll zu', ar: 'أوافق بشدة', ru: 'Полностью согласен', es: 'Totalmente de acuerdo', it: 'Fortemente d’accordo' } },
+  { value: 1, label: { zh: '非常不同意', 'zh-Hant': '非常不同意', en: 'Strongly disagree', ja: 'まったくそう思わない', ko: '전혀 동의하지 않음', fr: 'Tout à fait en désaccord', de: 'Stimme überhaupt nicht zu', ar: 'أعارض بشدة', ru: 'Совершенно не согласен', es: 'Totalmente en desacuerdo', it: 'Fortemente in disaccordo', tr: 'Kesinlikle katılmıyorum', hi: 'पूरी तरह असहमत' } },
+  { value: 2, label: { zh: '不同意', 'zh-Hant': '不同意', en: 'Disagree', ja: 'そう思わない', ko: '동의하지 않음', fr: 'Pas d’accord', de: 'Stimme nicht zu', ar: 'أعارض', ru: 'Не согласен', es: 'En desacuerdo', it: 'In disaccordo', tr: 'Katılmıyorum', hi: 'असहमत' } },
+  { value: 3, label: { zh: '一般', 'zh-Hant': '一般', en: 'Neutral', ja: 'どちらでもない', ko: '보통', fr: 'Neutre', de: 'Neutral', ar: 'محايد', ru: 'Нейтрально', es: 'Neutral', it: 'Neutro', tr: 'Kararsızım', hi: 'तटस्थ' } },
+  { value: 4, label: { zh: '同意', 'zh-Hant': '同意', en: 'Agree', ja: 'そう思う', ko: '동의함', fr: 'D’accord', de: 'Stimme zu', ar: 'أوافق', ru: 'Согласен', es: 'De acuerdo', it: 'D’accordo', tr: 'Katılıyorum', hi: 'सहमत' } },
+  { value: 5, label: { zh: '非常同意', 'zh-Hant': '非常同意', en: 'Strongly agree', ja: 'とてもそう思う', ko: '매우 동의함', fr: 'Tout à fait d’accord', de: 'Stimme voll zu', ar: 'أوافق بشدة', ru: 'Полностью согласен', es: 'Totalmente de acuerdo', it: 'Fortemente d’accordo', tr: 'Tamamen katılıyorum', hi: 'पूरी तरह सहमत' } },
 ];
 


### PR DESCRIPTION
## Summary
- add Turkish and Hindi language detection
- translate UI, questions, and result pages for Turkish and Hindi
- localize legal page content in Turkish and Hindi

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check translations.js && node --check results.js && node --check legal.js`


------
https://chatgpt.com/codex/tasks/task_e_689b7bd4dbc08333a02e328267269488