### PR TITLE
feat: add hreflang and lang override

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,21 @@
   <meta property="og:type" content="website" />
   <meta property="og:locale" content="zh_CN" />
   <link rel="canonical" href="https://freepersonalityquizzesandtests.online/" />
+  <!-- Alternate language versions for SEO -->
+  <link rel="alternate" hreflang="x-default" href="https://freepersonalityquizzesandtests.online/" />
+  <link rel="alternate" hreflang="zh" href="https://freepersonalityquizzesandtests.online/" />
+  <link rel="alternate" hreflang="zh-Hant" href="https://freepersonalityquizzesandtests.online/?lang=zh-Hant" />
+  <link rel="alternate" hreflang="en" href="https://freepersonalityquizzesandtests.online/?lang=en" />
+  <link rel="alternate" hreflang="ja" href="https://freepersonalityquizzesandtests.online/?lang=ja" />
+  <link rel="alternate" hreflang="ko" href="https://freepersonalityquizzesandtests.online/?lang=ko" />
+  <link rel="alternate" hreflang="fr" href="https://freepersonalityquizzesandtests.online/?lang=fr" />
+  <link rel="alternate" hreflang="de" href="https://freepersonalityquizzesandtests.online/?lang=de" />
+  <link rel="alternate" hreflang="ar" href="https://freepersonalityquizzesandtests.online/?lang=ar" />
+  <link rel="alternate" hreflang="ru" href="https://freepersonalityquizzesandtests.online/?lang=ru" />
+  <link rel="alternate" hreflang="es" href="https://freepersonalityquizzesandtests.online/?lang=es" />
+  <link rel="alternate" hreflang="it" href="https://freepersonalityquizzesandtests.online/?lang=it" />
+  <link rel="alternate" hreflang="tr" href="https://freepersonalityquizzesandtests.online/?lang=tr" />
+  <link rel="alternate" hreflang="hi" href="https://freepersonalityquizzesandtests.online/?lang=hi" />
   <meta property="og:url" content="https://freepersonalityquizzesandtests.online/" />
   <script type="application/ld+json">
   {

--- a/legal.js
+++ b/legal.js
@@ -1,5 +1,11 @@
 // Language detection and translations for legal pages
 const LANG = (() => {
+  const params = new URLSearchParams(window.location.search);
+  const override = params.get('lang');
+  const supported = ['zh','zh-Hant','en','ja','ko','fr','de','ar','ru','es','it','tr','hi'];
+  if (override && supported.includes(override)) {
+    return override;
+  }
   const l = (navigator.language || 'en').toLowerCase();
   if (l.startsWith('zh')) {
     return /tw|hk|mo|hant/.test(l) ? 'zh-Hant' : 'zh';

--- a/privacy.html
+++ b/privacy.html
@@ -6,6 +6,21 @@
   <title>隐私政策｜Psychotest</title>
   <meta name="description" content="Psychotest 隐私政策。" />
   <link rel="canonical" href="https://freepersonalityquizzesandtests.online/privacy.html" />
+  <!-- Alternate language versions for SEO -->
+  <link rel="alternate" hreflang="x-default" href="https://freepersonalityquizzesandtests.online/privacy.html" />
+  <link rel="alternate" hreflang="zh" href="https://freepersonalityquizzesandtests.online/privacy.html" />
+  <link rel="alternate" hreflang="zh-Hant" href="https://freepersonalityquizzesandtests.online/privacy.html?lang=zh-Hant" />
+  <link rel="alternate" hreflang="en" href="https://freepersonalityquizzesandtests.online/privacy.html?lang=en" />
+  <link rel="alternate" hreflang="ja" href="https://freepersonalityquizzesandtests.online/privacy.html?lang=ja" />
+  <link rel="alternate" hreflang="ko" href="https://freepersonalityquizzesandtests.online/privacy.html?lang=ko" />
+  <link rel="alternate" hreflang="fr" href="https://freepersonalityquizzesandtests.online/privacy.html?lang=fr" />
+  <link rel="alternate" hreflang="de" href="https://freepersonalityquizzesandtests.online/privacy.html?lang=de" />
+  <link rel="alternate" hreflang="ar" href="https://freepersonalityquizzesandtests.online/privacy.html?lang=ar" />
+  <link rel="alternate" hreflang="ru" href="https://freepersonalityquizzesandtests.online/privacy.html?lang=ru" />
+  <link rel="alternate" hreflang="es" href="https://freepersonalityquizzesandtests.online/privacy.html?lang=es" />
+  <link rel="alternate" hreflang="it" href="https://freepersonalityquizzesandtests.online/privacy.html?lang=it" />
+  <link rel="alternate" hreflang="tr" href="https://freepersonalityquizzesandtests.online/privacy.html?lang=tr" />
+  <link rel="alternate" hreflang="hi" href="https://freepersonalityquizzesandtests.online/privacy.html?lang=hi" />
   <meta property="og:title" content="隐私政策｜Psychotest" />
   <meta property="og:description" content="Psychotest 隐私政策。" />
   <meta property="og:type" content="website" />

--- a/results.js
+++ b/results.js
@@ -1,5 +1,11 @@
 // Shared translation data and renderer for result pages
 function detectLang() {
+  const params = new URLSearchParams(window.location.search);
+  const override = params.get('lang');
+  const supported = ['zh','zh-Hant','en','ja','ko','fr','de','ar','ru','es','it','tr','hi'];
+  if (override && supported.includes(override)) {
+    return override;
+  }
   const l = (navigator.language || 'en').toLowerCase();
   if (l.startsWith('zh')) {
     return /tw|hk|mo|hant/.test(l) ? 'zh-Hant' : 'zh';

--- a/results/analyst.html
+++ b/results/analyst.html
@@ -11,6 +11,21 @@
   <meta property="og:type" content="article" />
   <meta property="og:locale" content="zh_CN" />
     <link rel="canonical" href="https://freepersonalityquizzesandtests.online/results/analyst.html" />
+    <!-- Alternate language versions for SEO -->
+    <link rel="alternate" hreflang="x-default" href="https://freepersonalityquizzesandtests.online/results/analyst.html" />
+    <link rel="alternate" hreflang="zh" href="https://freepersonalityquizzesandtests.online/results/analyst.html" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://freepersonalityquizzesandtests.online/results/analyst.html?lang=zh-Hant" />
+    <link rel="alternate" hreflang="en" href="https://freepersonalityquizzesandtests.online/results/analyst.html?lang=en" />
+    <link rel="alternate" hreflang="ja" href="https://freepersonalityquizzesandtests.online/results/analyst.html?lang=ja" />
+    <link rel="alternate" hreflang="ko" href="https://freepersonalityquizzesandtests.online/results/analyst.html?lang=ko" />
+    <link rel="alternate" hreflang="fr" href="https://freepersonalityquizzesandtests.online/results/analyst.html?lang=fr" />
+    <link rel="alternate" hreflang="de" href="https://freepersonalityquizzesandtests.online/results/analyst.html?lang=de" />
+    <link rel="alternate" hreflang="ar" href="https://freepersonalityquizzesandtests.online/results/analyst.html?lang=ar" />
+    <link rel="alternate" hreflang="ru" href="https://freepersonalityquizzesandtests.online/results/analyst.html?lang=ru" />
+    <link rel="alternate" hreflang="es" href="https://freepersonalityquizzesandtests.online/results/analyst.html?lang=es" />
+    <link rel="alternate" hreflang="it" href="https://freepersonalityquizzesandtests.online/results/analyst.html?lang=it" />
+    <link rel="alternate" hreflang="tr" href="https://freepersonalityquizzesandtests.online/results/analyst.html?lang=tr" />
+    <link rel="alternate" hreflang="hi" href="https://freepersonalityquizzesandtests.online/results/analyst.html?lang=hi" />
     <meta property="og:url" content="https://freepersonalityquizzesandtests.online/results/analyst.html" />
   <script type="application/ld+json">
   {

--- a/results/connector.html
+++ b/results/connector.html
@@ -11,6 +11,21 @@
   <meta property="og:type" content="article" />
   <meta property="og:locale" content="zh_CN" />
     <link rel="canonical" href="https://freepersonalityquizzesandtests.online/results/connector.html" />
+    <!-- Alternate language versions for SEO -->
+    <link rel="alternate" hreflang="x-default" href="https://freepersonalityquizzesandtests.online/results/connector.html" />
+    <link rel="alternate" hreflang="zh" href="https://freepersonalityquizzesandtests.online/results/connector.html" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://freepersonalityquizzesandtests.online/results/connector.html?lang=zh-Hant" />
+    <link rel="alternate" hreflang="en" href="https://freepersonalityquizzesandtests.online/results/connector.html?lang=en" />
+    <link rel="alternate" hreflang="ja" href="https://freepersonalityquizzesandtests.online/results/connector.html?lang=ja" />
+    <link rel="alternate" hreflang="ko" href="https://freepersonalityquizzesandtests.online/results/connector.html?lang=ko" />
+    <link rel="alternate" hreflang="fr" href="https://freepersonalityquizzesandtests.online/results/connector.html?lang=fr" />
+    <link rel="alternate" hreflang="de" href="https://freepersonalityquizzesandtests.online/results/connector.html?lang=de" />
+    <link rel="alternate" hreflang="ar" href="https://freepersonalityquizzesandtests.online/results/connector.html?lang=ar" />
+    <link rel="alternate" hreflang="ru" href="https://freepersonalityquizzesandtests.online/results/connector.html?lang=ru" />
+    <link rel="alternate" hreflang="es" href="https://freepersonalityquizzesandtests.online/results/connector.html?lang=es" />
+    <link rel="alternate" hreflang="it" href="https://freepersonalityquizzesandtests.online/results/connector.html?lang=it" />
+    <link rel="alternate" hreflang="tr" href="https://freepersonalityquizzesandtests.online/results/connector.html?lang=tr" />
+    <link rel="alternate" hreflang="hi" href="https://freepersonalityquizzesandtests.online/results/connector.html?lang=hi" />
     <meta property="og:url" content="https://freepersonalityquizzesandtests.online/results/connector.html" />
   <script type="application/ld+json">
   {

--- a/results/explorer.html
+++ b/results/explorer.html
@@ -11,6 +11,21 @@
   <meta property="og:type" content="article" />
   <meta property="og:locale" content="zh_CN" />
     <link rel="canonical" href="https://freepersonalityquizzesandtests.online/results/explorer.html" />
+    <!-- Alternate language versions for SEO -->
+    <link rel="alternate" hreflang="x-default" href="https://freepersonalityquizzesandtests.online/results/explorer.html" />
+    <link rel="alternate" hreflang="zh" href="https://freepersonalityquizzesandtests.online/results/explorer.html" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://freepersonalityquizzesandtests.online/results/explorer.html?lang=zh-Hant" />
+    <link rel="alternate" hreflang="en" href="https://freepersonalityquizzesandtests.online/results/explorer.html?lang=en" />
+    <link rel="alternate" hreflang="ja" href="https://freepersonalityquizzesandtests.online/results/explorer.html?lang=ja" />
+    <link rel="alternate" hreflang="ko" href="https://freepersonalityquizzesandtests.online/results/explorer.html?lang=ko" />
+    <link rel="alternate" hreflang="fr" href="https://freepersonalityquizzesandtests.online/results/explorer.html?lang=fr" />
+    <link rel="alternate" hreflang="de" href="https://freepersonalityquizzesandtests.online/results/explorer.html?lang=de" />
+    <link rel="alternate" hreflang="ar" href="https://freepersonalityquizzesandtests.online/results/explorer.html?lang=ar" />
+    <link rel="alternate" hreflang="ru" href="https://freepersonalityquizzesandtests.online/results/explorer.html?lang=ru" />
+    <link rel="alternate" hreflang="es" href="https://freepersonalityquizzesandtests.online/results/explorer.html?lang=es" />
+    <link rel="alternate" hreflang="it" href="https://freepersonalityquizzesandtests.online/results/explorer.html?lang=it" />
+    <link rel="alternate" hreflang="tr" href="https://freepersonalityquizzesandtests.online/results/explorer.html?lang=tr" />
+    <link rel="alternate" hreflang="hi" href="https://freepersonalityquizzesandtests.online/results/explorer.html?lang=hi" />
     <meta property="og:url" content="https://freepersonalityquizzesandtests.online/results/explorer.html" />
   <script type="application/ld+json">
   {

--- a/results/organizer.html
+++ b/results/organizer.html
@@ -11,6 +11,21 @@
   <meta property="og:type" content="article" />
   <meta property="og:locale" content="zh_CN" />
     <link rel="canonical" href="https://freepersonalityquizzesandtests.online/results/organizer.html" />
+    <!-- Alternate language versions for SEO -->
+    <link rel="alternate" hreflang="x-default" href="https://freepersonalityquizzesandtests.online/results/organizer.html" />
+    <link rel="alternate" hreflang="zh" href="https://freepersonalityquizzesandtests.online/results/organizer.html" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://freepersonalityquizzesandtests.online/results/organizer.html?lang=zh-Hant" />
+    <link rel="alternate" hreflang="en" href="https://freepersonalityquizzesandtests.online/results/organizer.html?lang=en" />
+    <link rel="alternate" hreflang="ja" href="https://freepersonalityquizzesandtests.online/results/organizer.html?lang=ja" />
+    <link rel="alternate" hreflang="ko" href="https://freepersonalityquizzesandtests.online/results/organizer.html?lang=ko" />
+    <link rel="alternate" hreflang="fr" href="https://freepersonalityquizzesandtests.online/results/organizer.html?lang=fr" />
+    <link rel="alternate" hreflang="de" href="https://freepersonalityquizzesandtests.online/results/organizer.html?lang=de" />
+    <link rel="alternate" hreflang="ar" href="https://freepersonalityquizzesandtests.online/results/organizer.html?lang=ar" />
+    <link rel="alternate" hreflang="ru" href="https://freepersonalityquizzesandtests.online/results/organizer.html?lang=ru" />
+    <link rel="alternate" hreflang="es" href="https://freepersonalityquizzesandtests.online/results/organizer.html?lang=es" />
+    <link rel="alternate" hreflang="it" href="https://freepersonalityquizzesandtests.online/results/organizer.html?lang=it" />
+    <link rel="alternate" hreflang="tr" href="https://freepersonalityquizzesandtests.online/results/organizer.html?lang=tr" />
+    <link rel="alternate" hreflang="hi" href="https://freepersonalityquizzesandtests.online/results/organizer.html?lang=hi" />
     <meta property="og:url" content="https://freepersonalityquizzesandtests.online/results/organizer.html" />
   <script type="application/ld+json">
   {

--- a/script.js
+++ b/script.js
@@ -85,9 +85,13 @@ function computeAndRedirect(e) {
     }
   });
 
-  // Redirect to result page with query string containing raw scores
-  const qs = new URLSearchParams(scores).toString();
-  const url = `results/${winner}.html?${qs}`;
+  // Redirect to result page with query string containing raw scores and language
+  const qs = new URLSearchParams(scores);
+  const currentLang = new URLSearchParams(window.location.search).get('lang');
+  if (currentLang) {
+    qs.set('lang', LANG);
+  }
+  const url = `results/${winner}.html?${qs.toString()}`;
   gtagSendEvent(url);
 }
 

--- a/terms.html
+++ b/terms.html
@@ -6,6 +6,21 @@
   <title>服务条款｜Psychotest</title>
   <meta name="description" content="Psychotest 服务条款。" />
   <link rel="canonical" href="https://freepersonalityquizzesandtests.online/terms.html" />
+  <!-- Alternate language versions for SEO -->
+  <link rel="alternate" hreflang="x-default" href="https://freepersonalityquizzesandtests.online/terms.html" />
+  <link rel="alternate" hreflang="zh" href="https://freepersonalityquizzesandtests.online/terms.html" />
+  <link rel="alternate" hreflang="zh-Hant" href="https://freepersonalityquizzesandtests.online/terms.html?lang=zh-Hant" />
+  <link rel="alternate" hreflang="en" href="https://freepersonalityquizzesandtests.online/terms.html?lang=en" />
+  <link rel="alternate" hreflang="ja" href="https://freepersonalityquizzesandtests.online/terms.html?lang=ja" />
+  <link rel="alternate" hreflang="ko" href="https://freepersonalityquizzesandtests.online/terms.html?lang=ko" />
+  <link rel="alternate" hreflang="fr" href="https://freepersonalityquizzesandtests.online/terms.html?lang=fr" />
+  <link rel="alternate" hreflang="de" href="https://freepersonalityquizzesandtests.online/terms.html?lang=de" />
+  <link rel="alternate" hreflang="ar" href="https://freepersonalityquizzesandtests.online/terms.html?lang=ar" />
+  <link rel="alternate" hreflang="ru" href="https://freepersonalityquizzesandtests.online/terms.html?lang=ru" />
+  <link rel="alternate" hreflang="es" href="https://freepersonalityquizzesandtests.online/terms.html?lang=es" />
+  <link rel="alternate" hreflang="it" href="https://freepersonalityquizzesandtests.online/terms.html?lang=it" />
+  <link rel="alternate" hreflang="tr" href="https://freepersonalityquizzesandtests.online/terms.html?lang=tr" />
+  <link rel="alternate" hreflang="hi" href="https://freepersonalityquizzesandtests.online/terms.html?lang=hi" />
   <meta property="og:title" content="服务条款｜Psychotest" />
   <meta property="og:description" content="Psychotest 服务条款。" />
   <meta property="og:type" content="website" />

--- a/translations.js
+++ b/translations.js
@@ -1,5 +1,11 @@
 // Language detection and translation data for index page
 const LANG = (() => {
+  const params = new URLSearchParams(window.location.search);
+  const override = params.get('lang');
+  const supported = ['zh','zh-Hant','en','ja','ko','fr','de','ar','ru','es','it','tr','hi'];
+  if (override && supported.includes(override)) {
+    return override;
+  }
   const l = (navigator.language || 'en').toLowerCase();
   if (l.startsWith('zh')) {
     return /tw|hk|mo|hant/.test(l) ? 'zh-Hant' : 'zh';


### PR DESCRIPTION
## Summary
- support `?lang` query parameter across index, results, and legal pages
- add `hreflang` alternate links for all supported languages to improve SEO
- preserve language choice when navigating to result pages

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c18fa7ff48333b192c66d4fdf114f